### PR TITLE
Remove zsh shebangs from files not for independent execution [DOT-26]

### DIFF
--- a/shell/aliases.zsh
+++ b/shell/aliases.zsh
@@ -1,5 +1,3 @@
-#!/usr/bin/env zsh
-
 alias bat='bat --paging=never'
 alias br='bin/rubocop'
 alias bs='bin/rspec'

--- a/shell/functions.zsh
+++ b/shell/functions.zsh
@@ -1,5 +1,3 @@
-#!/usr/bin/env zsh
-
 # bundle
 b() { bundle install }
 

--- a/shell/linux.zsh
+++ b/shell/linux.zsh
@@ -1,3 +1,1 @@
-#!/usr/bin/env zsh
-
 eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"

--- a/zshrc.zsh
+++ b/zshrc.zsh
@@ -1,5 +1,3 @@
-#!/usr/bin/env zsh
-
 setopt +o nomatch # https://unix.stackexchange.com/a/310553/276727
 export EDITOR='code'
 export ZSH=$HOME/.oh-my-zsh


### PR DESCRIPTION
I had added these zsh shebangs to try to get our ShellCheck GitHub action not to lint them, but that didn't work. (Instead, I ultimately changed the extensions from `.sh` to `.zsh` and added an exclude rule to the GitHub Action to not lint `.zsh` files.)