### PR TITLE
Separate out a prune-remote-branches-in-background script

### DIFF
--- a/bin/gdm
+++ b/bin/gdm
@@ -29,12 +29,4 @@ git for-each-ref --format='%(refname:short)' refs/heads |
 
 # check back out the branch that we were originally on
 git checkout --quiet -
-# delete remote branches that we don't need anymore
-{
-  current_directory=$(basename "$PWD")
-  (
-    git remote prune origin && \
-      notify "Job complete in $current_directory" 'Pruned remote branches' || \
-      notify-error "Job failed in $current_directory" 'Prune remote branches'
-  ) & disown
-} > /dev/null 2>&1
+prune-remote-branches-in-background

--- a/bin/prune-remote-branches-in-background
+++ b/bin/prune-remote-branches-in-background
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Delete (via a background process) remote branches that we don't need anymore.
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+{
+  current_directory=$(basename "$PWD")
+  (
+    git remote prune origin && \
+      notify "Job complete in $current_directory" 'Pruned remote branches' || \
+      notify-error "Job failed in $current_directory" 'Prune remote branches'
+  ) & disown
+} > /dev/null 2>&1

--- a/bin/prune-remote-branches-in-background
+++ b/bin/prune-remote-branches-in-background
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env zsh
 
 # Delete (via a background process) remote branches that we don't need anymore.
 


### PR DESCRIPTION
This will make that code reusable elsewhere (such as in my `dotfiles-personal`` `wait-merge` script).