### PR TITLE
[bin-lint] Introduce bin-lint/ directory (initially with gitleaks)

### DIFF
--- a/bin-lint/gitleaks
+++ b/bin-lint/gitleaks
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Run Gitleaks to protect against committed secrets.
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+if gitleaks detect --log-opts="origin/$(main-branch)..." &> /dev/null ; then
+  echo 'Gitleaks did not detect any committed secrets.'
+else
+  gitleaks detect --log-opts="origin/$(main-branch)..." --verbose
+fi

--- a/bin/lint
+++ b/bin/lint
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Execute a linter script defined in this repo's `bin-lint/` directory.
+#
+# Example:
+#   lint gitleaks
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+linter=$1
+
+"$HOME/code/dotfiles/bin-lint/$linter"


### PR DESCRIPTION
The idea of this directory is that, for linting scripts that don't vary at all between repos, we can just point the repo to run the scripts that will live (in a DRY fashion) here.

For linting steps that do vary between repos, though, we'll continue to have those linting scripts live in the individual repos.