### PR TITLE
Globalize eslint, prettier, rubocop, stylelint, typescript [DOT-37]

### DIFF
--- a/bin-lint/eslint
+++ b/bin-lint/eslint
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Run ESLint.
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+readarray -t files_for_eslint < <(
+  changed-not-deleted-files | \
+    rg "app/javascript/.*\.(js|ts|vue)$" || \
+    true
+)
+
+git_diff_hash_before=$(git diff | sha1sum | choose 0)
+
+if [ ${#files_for_eslint[@]} -eq 0 ]; then
+  write-background-notification 'No files need to be linted by ESLint.'
+else
+  set +e
+  (
+    set -x
+    ./node_modules/.bin/eslint --max-warnings 0 --fix "${files_for_eslint[@]}"
+  )
+  eslint_status=$?
+  set -e
+
+  if [ $eslint_status -eq 0 ]; then
+    git_diff_hash_after=$(git diff | sha1sum | choose 0)
+
+    if [ "$git_diff_hash_before" == "$git_diff_hash_after" ] ; then
+      write-background-notification 'Changed files satisfy ESLint.'
+    else
+      write-background-notification 'There were ESLint violation(s). They were all autocorrected.'
+      exit 1
+    fi
+  else
+    write-background-notification 'There were ESLint violations(s) that could not be autocorrected.'
+    exit 1
+  fi
+fi

--- a/bin-lint/prettier
+++ b/bin-lint/prettier
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Run Prettier.
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+# Every file must have a period somewhere (either a dotfile or file extension).
+# Ruby files aren't linted by Prettier.
+readarray -t files_for_prettier < <(
+  changed-not-deleted-files | \
+    rg '\.' | \
+    rg -v '\.(haml|lock|rb)$' || \
+    true
+)
+
+git_diff_hash_before=$(git diff | sha1sum | choose 0)
+
+if [ ${#files_for_prettier[@]} -eq 0 ]; then
+  write-background-notification 'No files need to be linted by Prettier.'
+else
+  set +e
+  (
+    set -x
+    ./node_modules/.bin/prettier --write --log-level=error "${files_for_prettier[@]}"
+  )
+  set -e
+
+  git_diff_hash_after=$(git diff | sha1sum | choose 0)
+
+  if [ "$git_diff_hash_before" == "$git_diff_hash_after" ] ; then
+    write-background-notification 'Changed files satisfy Prettier.'
+  else
+    write-background-notification 'There were Prettier violation(s). They were all corrected.'
+    exit 1
+  fi
+fi

--- a/bin-lint/rubocop
+++ b/bin-lint/rubocop
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Run RuboCop.
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+# Either:
+# 1. filename ends with .arb, .rake, .rb, or .ru.
+# 2. filename has no extension (e.g. `Gemfile` or `.irbrc`)
+readarray -t files_for_rubocop < <(
+  changed-not-deleted-files | \
+    rg '^(.*\.(arb|rake|rb|ru)|[^.]*|\.[^.]+)$' | \
+    xargs -r rg --files-without-match '^#!/usr/bin/env (bash|sh|zsh)' || \
+    true
+)
+
+git_diff_hash_before=$(git diff | sha1sum | choose 0)
+
+if [ ${#files_for_rubocop[@]} -eq 0 ] ; then
+  write-background-notification 'No files need to be linted by RuboCop.'
+else
+  set +e
+  (
+    set -x
+    bin/rubocop \
+      --only-recognized-file-types --force-exclusion --autocorrect-all \
+      "${files_for_rubocop[@]}"
+  )
+  rubocop_status=$?
+  set -e
+
+  if [ $rubocop_status -eq 0 ]; then
+    git_diff_hash_after=$(git diff | sha1sum | choose 0)
+
+    if [ "$git_diff_hash_before" == "$git_diff_hash_after" ] ; then
+      write-background-notification 'Changed files satisfy RuboCop.'
+    else
+      write-background-notification 'There were RuboCop violation(s). They were all autocorrected.'
+      exit 1
+    fi
+  else
+    write-background-notification 'There were RuboCop violation(s) that could not be autocorrected.'
+    exit 1
+  fi
+fi

--- a/bin-lint/stylelint
+++ b/bin-lint/stylelint
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Run Stylelint.
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+readarray -t files_for_stylelint < <(
+  changed-not-deleted-files | \
+    rg "app/.*\.(css|scss|vue)$" || \
+    true
+)
+
+git_diff_hash_before=$(git diff | sha1sum | choose 0)
+
+if [ ${#files_for_stylelint[@]} -eq 0 ]; then
+  write-background-notification 'No files need to be linted by Stylelint.'
+else
+  set +e
+  (
+    set -x
+    ./node_modules/.bin/stylelint --max-warnings 0 --fix "${files_for_stylelint[@]}"
+  )
+  stylelint_status=$?
+  set -e
+
+  if [ $stylelint_status -eq 0 ]; then
+    git_diff_hash_after=$(git diff | sha1sum | choose 0)
+
+    if [ "$git_diff_hash_before" == "$git_diff_hash_after" ] ; then
+      write-background-notification 'Changed files satisfy Stylelint.'
+    else
+      write-background-notification 'There were Stylelint violation(s). They were all autocorrected.'
+      exit 1
+    fi
+  else
+    write-background-notification 'There were Stylelint violation(s) that could not be autocorrected.'
+    exit 1
+  fi
+fi

--- a/bin-lint/typescript
+++ b/bin-lint/typescript
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Check TypeScript types.
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+files_for_typescript=$(
+  changed-not-deleted-files | \
+    rg '\.(ts|vue)$' || \
+    true
+)
+
+if [[ $files_for_typescript != "" ]]; then
+  set -x
+  if ./node_modules/.bin/vue-tsc --noEmit ; then
+    write-background-notification 'Changed files satisfy TypeScript.'
+  else
+    write-background-notification 'There were TypeScript error(s).'
+    exit 1
+  fi
+else
+  write-background-notification 'No files need to be checked by TypeScript.'
+fi

--- a/bin/background-and-notify
+++ b/bin/background-and-notify
@@ -5,7 +5,6 @@
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
 message_filename=$(echo "$@" | tr ' ' '-')
-
 message_path=personal/background-messages/$message_filename.txt
 
 rm -f $message_path
@@ -15,7 +14,7 @@ echo "Running \`$*\` in the background."
 set +e
 {
   (
-    BACKGROUND_AND_NOTIFY_FILENAME="$message_filename" "$@" > /dev/null 2>&1
+    BACKGROUND_AND_NOTIFY_MESSAGE_PATH="$message_path" "$@" > /dev/null 2>&1
     exit_status=$?
     set -e
 

--- a/bin/perform-background-step
+++ b/bin/perform-background-step
@@ -4,13 +4,13 @@
 
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
-program=$1
-message_path=personal/background-messages/$program.txt
+message_filename=$(echo "$@" | tr ' ' '-')
+message_path=personal/background-messages/$message_filename.txt
 
 rm -f "$message_path"
 
 set +e
-BACKGROUND_AND_NOTIFY_FILENAME="$program" $program
+BACKGROUND_AND_NOTIFY_MESSAGE_PATH="$message_path" "$@"
 exit_status=$?
 set -e
 
@@ -24,7 +24,7 @@ else
 fi
 
 if [ $exit_status -eq 0 ] ; then
-  notify "$program succeeded in $current_directory" "$message"
+  notify "\`$*\` succeeded in $current_directory" "$message"
 else
-  notify-error "$program failed in $current_directory" "$message"
+  notify-error "\`$*\` failed in $current_directory" "$message"
 fi

--- a/bin/write-background-notification
+++ b/bin/write-background-notification
@@ -6,9 +6,8 @@ set -euo pipefail # exit on any error, don't allow undefined variables, pipes do
 
 message=$1
 
-if [ -v BACKGROUND_AND_NOTIFY_FILENAME ] ; then
-  message_filename=$BACKGROUND_AND_NOTIFY_FILENAME
-  message_path=personal/background-messages/$message_filename.txt
+if [ -v BACKGROUND_AND_NOTIFY_MESSAGE_PATH ] ; then
+  message_path=$BACKGROUND_AND_NOTIFY_MESSAGE_PATH
   mf "$message_path"
   echo "$message" > "$message_path"
 else


### PR DESCRIPTION
Also, update `bin/perform-background-step` to handle multiple arguments (e.g. `lint eslint`).

Also, simplify background message writing a little by passing the whole path as an env var, not just the filename.