### PR TITLE
Rename condition to 'may-edit-latest-commit'

### DIFF
--- a/bin/gcoma
+++ b/bin/gcoma
@@ -5,7 +5,7 @@
 
 set -eo pipefail # exit on any error, pipes don't swallow errors
 
-if use-strict-git-rules && ! ahead-of-remote-branch ; then
+if use-strict-git-rules && ! may-edit-latest-commit ; then
   echo "Refusing to amend commit because you are not ahead of origin/$(branch)!"
 elif ahead-of-main ; then
   if [ -z "$1" ] ; then

--- a/bin/gup
+++ b/bin/gup
@@ -14,7 +14,7 @@ if [[ $(git rev-list --right-only --count "origin/$(main-branch)...HEAD") -eq 0 
   exit 1
 fi
 
-if use-strict-git-rules && ! ahead-of-remote-branch ; then
+if use-strict-git-rules && ! may-edit-latest-commit ; then
   echo "Not updating, because use-strict-git-rules is true" \
     "and you are not ahead of origin/$(branch)."
   exit 1

--- a/bin/may-edit-latest-commit
+++ b/bin/may-edit-latest-commit
@@ -7,6 +7,6 @@ set -euo pipefail # exit on any error, don't allow undefined variables, pipes do
 # If the branch doesn't even exist on the remote, then we are essentially "ahead" of it.
 if ! branch-exists-on-remote ; then
   exit 0
+else
+  ahead-of-branch "origin/$(branch)"
 fi
-
-[[ $(git rev-list --right-only --count "origin/$(branch)"...HEAD) -gt 0 ]]


### PR DESCRIPTION
It was unclear before why we were saying that, if the branch does not exist on the remote, then we are "ahead of the remote branch". What we were actually asking is whether the most recent commit can be edited. So let's name it that way.