### PR TITLE
[wait-merge] Stop manually fetching updates into main branch

### DIFF
--- a/bin/wait-merge
+++ b/bin/wait-merge
@@ -9,9 +9,6 @@ export GH_CHECKS_BRANCH
 wait-for-gh-checks
 gh pr merge "$GH_CHECKS_BRANCH" --squash
 say "P R merged"
-git fetch --no-tags --quiet origin "$(main-branch):$(main-branch)"
-
-set -x
 
 # switch to "safe" branch if still on the local branch that was just merged
 if [[ "$(branch)" == "$GH_CHECKS_BRANCH" ]]; then


### PR DESCRIPTION
Instead, we'll use either `safe` or `update-main-branches` below.

Motivation: the `git fetch` command will fail (due to being non-fast-forward) if `main` is ahead of its remote. The other commands mentioned, which we'll now rely on instead, will not fail in this case.