### PR TITLE
[parse-vs-code-theme] Add tool to format downloaded VS Code theme

### DIFF
--- a/tools/parse-vs-code-theme.rb
+++ b/tools/parse-vs-code-theme.rb
@@ -1,0 +1,36 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# This tool parses the VS Code theme data output from themes.vscode.one and
+# formats it in the way required by the VS Coe settings.json file.
+#
+# Example (copies the formatted theme JSON to the clipboard):
+#   ~/code/dotfiles/tools/parse-vs-code-theme.rb ~/Downloads/bloom-1-1-0-fork-color-theme.json
+
+require 'json'
+
+theme_data = JSON.parse(File.read(ARGV[0]))
+token_colors = theme_data['tokenColors']
+colors = theme_data['colors']
+
+hash_for_vs_code = {
+  'editor.tokenColorCustomizations' => {
+    'textMateRules' => token_colors,
+  },
+  'workbench.colorCustomizations' => colors,
+}
+
+class String
+  def pipe(command)
+    IO.popen(command, 'r+') do |io|
+      io.puts(self)
+      io.close_write
+      io.read
+    end
+  end
+end
+
+JSON.dump(hash_for_vs_code).
+  pipe('prettier --stdin-filepath=x.json').
+  pipe("sed '1d;$d'").
+  pipe('cpy')


### PR DESCRIPTION
1. go to https://themes.vscode.one/your-themes
2. click edit icon for "Bloom 1.1.0 - Fork" theme
3. make desired changes to theme
4. go back to index view
5. click download icon
6. run this script as illustrated in the documentation comment
7. open VS Code settings JSON
8. delete existing theme information
9. paste the theme information from your clipboard
10. save
11. => VS Code should immediately reflect the new theme