### PR TITLE
[wait-for-gh-checks] Wait an initial 5 seconds [DOT-46]

### DIFF
--- a/bin/wait-for-gh-checks
+++ b/bin/wait-for-gh-checks
@@ -32,6 +32,10 @@ class WaitForChecksRunner
   end
 
   def run
+    # Wait an initial 5 seconds, so that failed checks from a previous run
+    # aren't inaccurately considered as failing checks for the current run.
+    sleep(5)
+
     Printer.printing_in_place do |printer|
       loop do
         ::WaitForChecksRunner::LoopRunner.new(


### PR DESCRIPTION
If tests failed in a previous run, and then I push again, there is a risk that the old checks will still be considered active, and `wait-for-gh-checks` will fail immediately due to the previously failed checks. To mitigate against this, wait for an initial 5 seconds before performing the first check.