### PR TITLE
[gitconfig] Add blame.ignoreRevsFile = .git-blame-ignore-revs

### DIFF
--- a/git/gitconfig
+++ b/git/gitconfig
@@ -1,3 +1,5 @@
+[blame]
+  ignoreRevsFile = .git-blame-ignore-revs
 [core]
   excludesfile = ~/.gitignore
   pager = delta


### PR DESCRIPTION
It seems that GitLens (the VS Code extension) already respects this, even if git hasn't been configured to respect it, so I hadn't noticed that I didn't have this configured at the git level. But, indeed, I didn't, and so a CLI `git blame` would include commits that I want to ignore. This fixes that.