### PR TITLE
[gal] Don't run a bunch of times after bulk file changes [DOT-8]

### DIFF
--- a/guardfiles/run_bash.rb
+++ b/guardfiles/run_bash.rb
@@ -3,7 +3,7 @@
 # This is used by `gal` when the `bash` `--guardfile` option is used.
 
 require 'fileutils'
-require 'guard/shell'
+require_relative "#{Dir.home}/code/dotfiles/utils/ruby/guard_shell_with_guard_monkeypatch.rb"
 
 FileUtils.chmod('+x', './personal/bash.sh')
 

--- a/guardfiles/run_jest.rb
+++ b/guardfiles/run_jest.rb
@@ -3,7 +3,7 @@
 # This is used by `gal` when the `jest` `--guardfile` option is used.
 
 require 'active_support/core_ext/string/filters'
-require 'guard/shell'
+require_relative "#{Dir.home}/code/dotfiles/utils/ruby/guard_shell_with_guard_monkeypatch.rb"
 
 guard(:shell, all_on_start: true) do
   # https://web.archive.org/web/20200927034139/https://github.com/guard/listen/wiki/Duplicate-directory-errors

--- a/guardfiles/run_node.rb
+++ b/guardfiles/run_node.rb
@@ -4,7 +4,7 @@
 
 require 'active_support/core_ext/string/filters'
 require 'amazing_print'
-require 'guard/shell'
+require_relative "#{Dir.home}/code/dotfiles/utils/ruby/guard_shell_with_guard_monkeypatch.rb"
 
 guard(:shell, all_on_start: true) do
   directories_to_watch = %w[app bin lib personal spec].select { Dir.exist?(_1) }

--- a/guardfiles/run_rails.rb
+++ b/guardfiles/run_rails.rb
@@ -2,7 +2,7 @@
 
 # This is used by `gal` when the `rails` `--guardfile` option is used.
 
-require 'guard/shell'
+require_relative "#{Dir.home}/code/dotfiles/utils/ruby/guard_shell_with_guard_monkeypatch.rb"
 
 guard(:shell, all_on_start: true) do
   directories_to_watch = %w[app bin lib personal spec].select { Dir.exist?(_1) }

--- a/guardfiles/run_ruby.rb
+++ b/guardfiles/run_ruby.rb
@@ -2,7 +2,7 @@
 
 # This is used by `gal` when the `ruby` `--guardfile` option is used.
 
-require 'guard/shell'
+require_relative "#{Dir.home}/code/dotfiles/utils/ruby/guard_shell_with_guard_monkeypatch.rb"
 
 NUM_BACKTRACE_LINES_TO_PRINT = 5
 

--- a/guardfiles/run_sidekiq.rb
+++ b/guardfiles/run_sidekiq.rb
@@ -2,8 +2,8 @@
 
 # This is used by `gal` when the `sidekiq` `--guardfile` option is used.
 
-require 'guard/shell'
 require 'sidekiq'
+require_relative "#{Dir.home}/code/dotfiles/utils/ruby/guard_shell_with_guard_monkeypatch.rb"
 
 Sidekiq.configure_client do |config|
   config.redis = { db: 3 }

--- a/guardfiles/run_spec.rb
+++ b/guardfiles/run_spec.rb
@@ -3,8 +3,7 @@
 # This is used by `gal` when the `spec` `--guardfile` option is used.
 
 require 'active_support/core_ext/string/filters'
-require 'guard/shell'
-
+require_relative "#{Dir.home}/code/dotfiles/utils/ruby/guard_shell_with_guard_monkeypatch.rb"
 require_relative "#{Dir.home}/code/dotfiles/utils/ruby/memoization.rb"
 
 class RspecPrefixer

--- a/guardfiles/run_sql.rb
+++ b/guardfiles/run_sql.rb
@@ -2,9 +2,9 @@
 
 # This is used by `gal` when the `jest` `--guardfile` option is used.
 
-require_relative "#{Dir.home}/code/dotfiles/utils/ruby/sql_utils.rb"
 require 'active_support/core_ext/string/filters'
-require 'guard/shell'
+require_relative "#{Dir.home}/code/dotfiles/utils/ruby/guard_shell_with_guard_monkeypatch.rb"
+require_relative "#{Dir.home}/code/dotfiles/utils/ruby/sql_utils.rb"
 
 class Runner
   include SqlUtils

--- a/utils/ruby/guard_shell_with_guard_monkeypatch.rb
+++ b/utils/ruby/guard_shell_with_guard_monkeypatch.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# This avoids re-running specs (or other guard-watched scripts) multiple times
+# when a file is saved multiple times while the spec(s) are executing or if a
+# bunch of files are updated at once (e.g. via a bulk save in the editor or via
+# a git rebase). Instead, just run once after the most recent modification.
+
+# This breaks with the idea of guard, which is that if file X is modified, then
+# we need to take action Y, and if file A is modified, then we need to take
+# action B. Instead, this monkeypatch assumes that if X or A is modified, then
+# we just need to take action M (and only one time). In the way that we are
+# currently using guard, this assumption is true.
+
+require 'guard/shell'
+
+module RungerGuardWatcherPatches
+  def match_files(guard, files)
+    super(guard, files.empty? ? [] : [files.first])
+  end
+end
+
+Guard::Watcher.singleton_class.prepend(RungerGuardWatcherPatches)


### PR DESCRIPTION
This avoids re-running specs (or other guard-watched scripts) multiple times when a file is saved multiple times while the spec(s) are executing or if a bunch of files are updated at once (e.g. via a bulk save in the editor or via a git rebase). Instead, just run once after the most recent modification

This breaks with the idea of guard, which is that if file X is modified, then we need to take action Y, and if file A is modified, then we need to take action B. Instead, this monkeypatch assumes that if X or A is modified, then we just need to take action M (and only one time). In the way that we are currently using guard, this assumption is true.