### PR TITLE
[iterm_opener] Remove unused open3 require

### DIFF
--- a/bin/iterm_opener
+++ b/bin/iterm_opener
@@ -4,8 +4,6 @@
 # When cmd-clicking something in iTerm, this opens the file/link/etc with an appropriate program
 # (because I have told iTerm to do that within the iTerm settings/preferences).
 
-require 'open3'
-
 # Printed output gets suppressed, but we can write debugging messages to a file.
 # rubocop:disable Style/TopLevelMethodDefinition
 def debug(message)


### PR DESCRIPTION
The `require` was added in 612fbf72 but then usage of the `Open3` library was dropped in 002f1ffc; the `require` should have been removed then.