### PR TITLE
[gal/node] Switch from ts-node to tsx to work w/ TypeScript [DOT-47]

### DIFF
--- a/bin/gal
+++ b/bin/gal
@@ -78,7 +78,7 @@ class Runner
       BASH
     },
     node: {
-      path: 'app/javascript/typescript.ts',
+      path: 'app/javascript/typescript-scratchpad.ts',
     },
     rails: {
       path: 'personal/runner.rb',

--- a/global_gitignore
+++ b/global_gitignore
@@ -20,6 +20,3 @@ app/workers/load_runner.rb
 # we need this to be in `app/javascript/` (not `personal/`) to use the project TypeScript config
 # We can't have a file called `typescript.ts`!
 app/javascript/typescript-scratchpad.ts
-app/javascript/typescript-scratchpad.tsx
-# we need this config for `ts-node` to work correctly (https://stackoverflow.com/a/72507086/4009384)
-node.tsconfig.json

--- a/guardfiles/run_node.rb
+++ b/guardfiles/run_node.rb
@@ -22,8 +22,8 @@ guard(:shell, all_on_start: true) do
       start_time = Time.now
       # rubocop:enable Rails/TimeZone, Lint/RedundantCopDisableDirective
       system('clear')
-      system(<<~SH.squish.tap { puts(_1) }, exception: true)
-        ts-node --project ./node.tsconfig.json app/javascript/typescript.ts
+      system(<<~SH.squish, exception: true)
+        tsx app/javascript/typescript-scratchpad.ts
       SH
     rescue => error
       puts(AmazingPrint::Colors.red(error.ai))

--- a/install.sh
+++ b/install.sh
@@ -30,4 +30,4 @@ touch ~/.pry_history
 
 # brew bundle
 
-# pnpm add --global http-server
+# pnpm add --global http-server typescript tsx


### PR DESCRIPTION
It's amazing that `ts-node` is an endless hell of confusing error messages and configuration changes, whereas `tsx` just works out of the box. All hail `tsx`!