### PR TITLE
[ghist] Fix exception when number of commits is not specified

### DIFF
--- a/bin/ghist
+++ b/bin/ghist
@@ -41,7 +41,7 @@ class GitHistory < CommandLineProgram
 
   memo_wise \
   def num_commits_to_show
-    Integer(arguments[1]) || 3
+    Integer(arguments[1] || 3)
   end
 
   memo_wise \


### PR DESCRIPTION
Without this change, when running `ghist bin/ghist`, we get this error: 'Integer': can't convert nil into Integer (TypeError).