### PR TITLE
Remove simple_cov-formatter-terminal from Gemfile (and Gemfile.lock)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,5 @@ gem 'yard'
 
 group :test do
   gem 'rspec'
-  gem 'simple_cov-formatter-terminal'
   gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,6 @@ GEM
     concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     diff-lcs (1.5.1)
-    docile (1.4.0)
     drb (2.2.1)
     fcom (0.12.0)
       activesupport (>= 6, < 8)
@@ -87,7 +86,6 @@ GEM
     regexp_parser (2.9.2)
     rexml (3.3.2)
       strscan
-    rouge (4.3.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -125,25 +123,10 @@ GEM
       rbs (>= 3, < 4)
       sorbet-runtime (>= 0.5.10782)
     ruby-progressbar (1.13.0)
-    runger_config (5.2.0)
-      activesupport (>= 7.1.2)
     runger_style (2.12.0)
       prism (>= 0.24.0)
       rubocop (>= 1.38.0, < 2)
     shellany (0.0.1)
-    simple_cov-formatter-terminal (1.4.0)
-      activesupport (>= 7.0.4, < 8)
-      memo_wise (>= 1.7.0, < 2)
-      rouge (>= 4.0.0, < 5)
-      rspec-core (>= 3.11.0, < 4)
-      runger_config (>= 3.0.0)
-      simplecov (>= 0.21.2, < 1)
-    simplecov (0.22.0)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.12.3)
-    simplecov_json_formatter (0.1.4)
     slop (4.10.1)
     sorbet-runtime (0.5.11491)
     strscan (3.1.0)
@@ -177,7 +160,6 @@ DEPENDENCIES
   rubocop-rspec
   ruby-lsp
   runger_style
-  simple_cov-formatter-terminal
   slop
   tapp
   timecop


### PR DESCRIPTION
We don't need this gem listed "globally" here in `dotfiles`, because the projects that use this gem have it listed in their own Gemfiles, as well, which is all we need.