### PR TITLE
[bolso/prompt] Add git ahead and behind counts [DOT-58]

### DIFF
--- a/zsh/themes/bolso.zsh-theme
+++ b/zsh/themes/bolso.zsh-theme
@@ -1,85 +1,18 @@
 # AVIT ZSH Theme
 
 PROMPT='
-${_current_dir} $(git_prompt_info) %D{%r}
+${_current_dir} $(git_prompt_info) $(git_commits_ahead) $(git_commits_behind) %D{%r}
 %{$fg[green]%}❯%{$reset_color%} '
 
 PROMPT2='%{$fg[grey]%}❮%{$reset_color%} '
-
-RPROMPT='$(_vi_status)%{$(echotc UP 1)%} %{$(echotc DO 1)%}'
-
-local _current_dir="%{$fg[cyan]%}%3~%{$reset_color%} "
-local _return_status="%{$fg[red]%}%(?..⍉)%{$reset_color%}"
-local _hist_no="%{$fg[grey]%}%h%{$reset_color%}"
-
-function _user_host() {
-  if [[ -n $SSH_CONNECTION ]]; then
-    me="%n@%m"
-  elif [[ $LOGNAME != $USER ]]; then
-    me="%n"
-  fi
-  if [[ -n $me ]]; then
-    echo "%{$fg[cyan]%}$me%{$reset_color%}:"
-  fi
-}
-
-function _vi_status() {
-  if {echo $fpath | grep -q "plugins/vi-mode"}; then
-    echo "$(vi_mode_prompt_info)"
-  fi
-}
-
-function _ruby_version() {
-  if {echo $fpath | grep -q "plugins/rvm"}; then
-    echo "%{$fg[grey]%}$(rvm_prompt_info)%{$reset_color%}"
-  fi
-}
-
-# Determine the time since last commit. If branch is clean,
-# use a neutral color, otherwise colors will vary according to time.
-function _git_time_since_commit() {
-  if git rev-parse --git-dir &>/dev/null; then
-    # Only proceed if there is actually a commit.
-    if [[ $(git log 2>&1 > /dev/null | grep -c "^fatal: bad default revision") == 0 ]]; then
-      # Get the last commit.
-      last_commit=$(git log --pretty=format:'%at' -1 2> /dev/null)
-      now=$(date +%s)
-      seconds_since_last_commit=$((now-last_commit))
-
-      # Totals
-      minutes=$((seconds_since_last_commit / 60))
-      hours=$((seconds_since_last_commit/3600))
-
-      # Sub-hours and sub-minutes
-      days=$((seconds_since_last_commit / 86400))
-      sub_hours=$((hours % 24))
-      sub_minutes=$((minutes % 60))
-
-      if [ $hours -gt 24 ]; then
-          commit_age="${days}d"
-      elif [ $minutes -gt 60 ]; then
-          commit_age="${sub_hours}h${sub_minutes}m"
-      else
-          commit_age="${minutes}m"
-      fi
-
-      color=$ZSH_THEME_GIT_TIME_SINCE_COMMIT_NEUTRAL
-      echo "$color$commit_age%{$reset_color%}"
-    fi
-  fi
-}
-
-if [[ $USER == "root" ]]; then
-  CARETCOLOR="red"
-else
-  CARETCOLOR="white"
-fi
-
 MODE_INDICATOR="%{$fg_bold[yellow]%}❮%{$reset_color%}%{$fg[yellow]%}❮❮%{$reset_color%}"
 
-ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[green]%}"
-ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
+local _current_dir="%{$fg[blue]%}%3~%{$reset_color%} "
 
+ZSH_THEME_GIT_COMMITS_AHEAD_SUFFIX="%{$fg[green]%}↥%{$reset_color%}"
+ZSH_THEME_GIT_COMMITS_BEHIND_SUFFIX="%{$fg[red]%}↧%{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[cyan]%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg[red]%}✗%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_CLEAN=" %{$fg[green]%}✔%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_ADDED="%{$fg[green]%}✚ "
@@ -88,13 +21,3 @@ ZSH_THEME_GIT_PROMPT_DELETED="%{$fg[red]%}✖ "
 ZSH_THEME_GIT_PROMPT_RENAMED="%{$fg[blue]%}▴ "
 ZSH_THEME_GIT_PROMPT_UNMERGED="%{$fg[cyan]%}§ "
 ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg[grey]%}◒ "
-
-# Colors vary depending on time lapsed.
-ZSH_THEME_GIT_TIME_SINCE_COMMIT_SHORT="%{$fg[green]%}"
-ZSH_THEME_GIT_TIME_SHORT_COMMIT_MEDIUM="%{$fg[yellow]%}"
-ZSH_THEME_GIT_TIME_SINCE_COMMIT_LONG="%{$fg[red]%}"
-ZSH_THEME_GIT_TIME_SINCE_COMMIT_NEUTRAL="%{$fg[grey]%}"
-
-# LS colors, made with http://geoff.greer.fm/lscolors/
-export LSCOLORS="exfxcxdxbxegedabagacad"
-export LS_COLORS='di=34:ln=35:so=32:pi=33:ex=31:bd=34;46:cd=34;43:su=30;41:sg=30;46:tw=30;42:ow=30;43'


### PR DESCRIPTION
Also, delete a lot of stuff we aren't actually using.

I might do this somewhat differently if I had full control, but, if I want to integrate with the oh-my-zsh theming system, then I don't have full control. The advantage of using the oh-my-zsh theming system is that I think it allows for asynchronicity, which should improve performance, which is an important benefit. Overall, I think this is good enough.

# Screenshot

![image](https://github.com/user-attachments/assets/7db21fb3-e58a-4bbc-838e-5b3d7af42448)