### PR TITLE
[cpy] Add support for a file argument [DOT-61]

### DIFF
--- a/bin/bytes
+++ b/bin/bytes
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Print the character codes (in decimal) of stdin.
+#
+# Example:
+#   echo 'hello' | bytes
+#   => prints '104 101 108 108 111  10'
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+od -An -t u1 -v

--- a/bin/cpy
+++ b/bin/cpy
@@ -2,16 +2,27 @@
 
 # [c]o[py] text to clipboard
 #
-# Copies text from stdin to clipboard (and prints the copied text).
+# Copies text from stdin or a file to the system clipboard (and prints the copied text).
 
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
-TEXT=$(</dev/stdin)
+# NOTE: Preserve and capture any trailing newline (which normally command
+# substitution won't do) by appending a '.' and then removing it.
+text=$(file-arg-content-or-stdin "$@"; echo -n .)
+text="${text%.}"
 
-if [ -v LINUX ]; then
-  echo -n $TEXT | xsel --clipboard --input
-else
-  echo -n $TEXT | pbcopy
+# If the string comes from stdin and has only one newline character which is at
+# the end of the string, then strip the trailing newline (which command
+# substitution will automatically do).
+if [ $# -eq 0 ] && [[ "${text: -1}" == $'\n' ]] && [[ "${text%$'\n'}" != *$'\n'* ]] ; then
+  text=$(echo "$text")
 fi
 
-echo "Text copied to clipboard:\n$TEXT"
+if [ -v LINUX ]; then
+  echo -En "$text" | xsel --clipboard --input
+else
+  echo -En "$text" | pbcopy
+fi
+
+echo 'Text copied to clipboard:'
+echo -En "$text"

--- a/bin/file-arg-content-or-stdin
+++ b/bin/file-arg-content-or-stdin
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# This program echoes to stdin the content of a file argument (if provided), or
+# else the stdin content piped into it, or else prints and exits with an error.
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+content=""
+
+# NOTE: Preserve and capture any trailing newline (which normally command
+# substitution won't do) by appending a '.' and then removing it.
+if [ $# -ge 1 ] ; then
+  content=$(cat "$1"; echo -n .)
+  content="${content%.}"
+elif [[ -p /dev/stdin ]] ; then
+  content=$(cat -; echo -n .)
+  content="${content%.}"
+else
+  echo "Error: received no arguments or stdin." >&2
+  exit 1
+fi
+
+echo -n "$content"


### PR DESCRIPTION
Up until now, `cpy` only supported copying piped input from stdin. This change adds support for another option, providing a file name argument (in which case the file's contents will be copied to the clipboard).

I'm also adding a `file-arg-content-or-stdin` executable, which does what it says on the tin.

I'm also adding a `bytes` command that will print the decimal ASCII character codes of any text piped into it. I used this `bytes` command to debug some of the issues related to newlines in `cpy` and `file-arg-content-or-stdin`.