### PR TITLE
[kitty_opener] Remove special case for json in file check

### DIFF
--- a/kitty/kitty_opener.py
+++ b/kitty/kitty_opener.py
@@ -26,7 +26,7 @@ def is_file_or_symlink_to_file(path, cwd):
 
     file_check_stdout = file_check.stdout
 
-    if file_check.returncode == 0 and re.search(r"json|text", file_check_stdout):
+    if file_check.returncode == 0 and re.search(r"text", file_check_stdout):
         return True
     elif match := re.search(symlink_extracting_regex, file_check_stdout):
         symbolic_link_target = match.group(1)


### PR DESCRIPTION
``` $ file config/vite.json config/vite.json: JSON text data ```

^ As can be seen in this example, the `file` output for a JSON file includes the string `text`, so the `json` search was doing nothing for us, especially since the regex (which doesn't have a case-insensitivity flag) has lowercase `json` whereas the `file` output has uppercase `JSON`.