### PR TITLE
[update-main-branches] Only check for changed file ack if configured

### DIFF
--- a/bin/update-main-branches
+++ b/bin/update-main-branches
@@ -12,7 +12,9 @@ fetch-main-branch
 
 update-main-branches-with-remote
 
-flag-unacked-file-versions
+if [ -f personal/.runger-monitored-paths.txt ] ; then
+  flag-unacked-file-versions
+fi
 
 # Switch back to the original branch.
 git checkout --quiet "$original_branch"


### PR DESCRIPTION
This will probably save at least 100ms each time that I execute `gform` (in a repository that doesn't have a `personal/.runger-monitored-paths.txt` file, which is most of them).