### PR TITLE
[gb] Only pipe to whitespace reducer if useful

### DIFF
--- a/bin/gb
+++ b/bin/gb
@@ -4,4 +4,10 @@
 
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
-git branch -vv --color | rg -v "\sz-" | git-branch-list-whitespace-reducer
+colored_branch_output=$(git branch -vv --color)
+
+if git branch --format='%(refname:short)' | rg --quiet '^z-' ; then
+  echo "$colored_branch_output" | rg -v "\sz-" | git-branch-list-whitespace-reducer
+else
+  echo "$colored_branch_output"
+fi


### PR DESCRIPTION
... i.e. if at least one 'z-' branch exists.

This takes the `gb` execution time (in repos without any `z-` branches) from ~600+ ms to ~40 ms!