### PR TITLE
[guardfiles] Don't watch lib/ directory if shard.yml is present

### DIFF
--- a/guardfiles/run_bash.rb
+++ b/guardfiles/run_bash.rb
@@ -10,6 +10,11 @@ FileUtils.chmod('+x', './personal/bash.sh')
 guard(:shell, all_on_start: true) do
   directories_to_watch = %w[app bin lib personal spec test].select { Dir.exist?(_1) }
 
+  # Don't watch `lib/` (the shards directory) if `shard.yml` exists.
+  if File.exist?('shard.yml')
+    directories_to_watch.reject! { _1 == 'lib' }
+  end
+
   # https://web.archive.org/web/20200927034139/https://github.com/guard/listen/wiki/Duplicate-directory-errors
   directories(directories_to_watch)
 

--- a/guardfiles/run_node.rb
+++ b/guardfiles/run_node.rb
@@ -7,7 +7,7 @@ require 'amazing_print'
 require_relative "#{Dir.home}/code/dotfiles/utils/ruby/guard_shell_with_guard_monkeypatch.rb"
 
 guard(:shell, all_on_start: true) do
-  directories_to_watch = %w[app bin lib personal spec].select { Dir.exist?(_1) }
+  directories_to_watch = %w[app personal].select { Dir.exist?(_1) }
 
   # https://web.archive.org/web/20200927034139/https://github.com/guard/listen/wiki/Duplicate-directory-errors
   directories(directories_to_watch)

--- a/guardfiles/run_ptest.rb
+++ b/guardfiles/run_ptest.rb
@@ -7,6 +7,11 @@ require_relative "#{Dir.home}/code/dotfiles/utils/ruby/guard_shell_with_guard_mo
 guard(:shell, all_on_start: true) do
   directories_to_watch = %w[app bin kitty lib personal test].select { Dir.exist?(_1) }
 
+  # Don't watch `lib/` (the shards directory) if `shard.yml` exists.
+  if File.exist?('shard.yml')
+    directories_to_watch.reject! { _1 == 'lib' }
+  end
+
   # https://web.archive.org/web/20200927034139/https://github.com/guard/listen/wiki/Duplicate-directory-errors
   directories(directories_to_watch)
 

--- a/guardfiles/run_python.rb
+++ b/guardfiles/run_python.rb
@@ -7,6 +7,11 @@ require_relative "#{Dir.home}/code/dotfiles/utils/ruby/guard_shell_with_guard_mo
 guard(:shell, all_on_start: true) do
   directories_to_watch = %w[app bin lib personal spec].select { Dir.exist?(_1) }
 
+  # Don't watch `lib/` (the shards directory) if `shard.yml` exists.
+  if File.exist?('shard.yml')
+    directories_to_watch.reject! { _1 == 'lib' }
+  end
+
   # https://web.archive.org/web/20200927034139/https://github.com/guard/listen/wiki/Duplicate-directory-errors
   directories(directories_to_watch)
 

--- a/guardfiles/run_ruby.rb
+++ b/guardfiles/run_ruby.rb
@@ -9,6 +9,11 @@ NUM_BACKTRACE_LINES_TO_PRINT = 5
 guard(:shell, all_on_start: true) do
   directories_to_watch = %w[app bin lib personal spec].select { Dir.exist?(_1) }
 
+  # Don't watch `lib/` (the shards directory) if `shard.yml` exists.
+  if File.exist?('shard.yml')
+    directories_to_watch.reject! { _1 == 'lib' }
+  end
+
   # https://web.archive.org/web/20200927034139/https://github.com/guard/listen/wiki/Duplicate-directory-errors
   directories(directories_to_watch)
 

--- a/guardfiles/run_spec.rb
+++ b/guardfiles/run_spec.rb
@@ -39,6 +39,11 @@ rspec_prefixer = RspecPrefixer.new
 guard(:shell, all_on_start: true) do
   directories_to_watch = %w[app bin lib personal spec].select { Dir.exist?(_1) }
 
+  # Don't watch `lib/` (the shards directory) if `shard.yml` exists.
+  if File.exist?('shard.yml')
+    directories_to_watch.reject! { _1 == 'lib' }
+  end
+
   # https://web.archive.org/web/20200927034139/https://github.com/guard/listen/wiki/Duplicate-directory-errors
   directories(directories_to_watch)
 

--- a/guardfiles/run_sql.rb
+++ b/guardfiles/run_sql.rb
@@ -16,6 +16,11 @@ runner = Runner.new
 guard(:shell, all_on_start: true) do
   directories_to_watch = %w[app bin lib personal spec].select { Dir.exist?(_1) }
 
+  # Don't watch `lib/` (the shards directory) if `shard.yml` exists.
+  if File.exist?('shard.yml')
+    directories_to_watch.reject! { _1 == 'lib' }
+  end
+
   # https://web.archive.org/web/20200927034139/https://github.com/guard/listen/wiki/Duplicate-directory-errors
   directories(directories_to_watch)
 


### PR DESCRIPTION
In this case, `lib/` contains the Crystal shards, and we get an error when trying to run guard.