### PR TITLE
[kitty_opener] Updated editor path from dotfiles-personal to dotfiles

### DIFF
--- a/kitty/kitty_opener.py
+++ b/kitty/kitty_opener.py
@@ -5,8 +5,8 @@ from pathlib import Path
 
 # NOTE: Debug with this function and run (in dotfiles) `gal -g bash --force` and
 # make the bash script `cat personal/random.txt`.
-# def debug(text):
-#     subprocess.run(f"echo '{text}' >> /home/david/code/dotfiles/personal/random.txt", shell=True)
+def debug(text):
+    subprocess.run(f"echo '{text}' >> /home/david/code/dotfiles/personal/random.txt", shell=True)
 
 symlink_extracting_regex = r": symbolic link to (.+)"
 
@@ -47,7 +47,7 @@ def github_path(cwd):
 
 
 home = str(Path.home())
-editor = f"{home}/code/dotfiles-personal/bin/editor"
+editor = f"{home}/code/dotfiles/bin/editor"
 
 
 regex = re.compile(

--- a/test/kitty_opener_test.py
+++ b/test/kitty_opener_test.py
@@ -32,6 +32,7 @@ class TestRegex(unittest.TestCase):
             ["{:locations=>{'./spec/bin/open_pr_in_browser_spec.rb'=>[19]}}", ["./spec/bin/open_pr_in_browser_spec.rb"]],
             ["(https://davidrunger.com/#projects?query=string)", ["https://davidrunger.com/#projects?query=string"]],
             ["bin/flag-unacked-file-versions:115:in `ack_data", ["bin/flag-unacked-file-versions:115"]],
+            ["RunFeatureTests : rspec ./spec/features/quizzes_spec.rb:9 # Quizzes app / when", ["./spec/features/quizzes_spec.rb:9"]],
         ]
 
         for input_text, expected_matches in test_cases:


### PR DESCRIPTION
I moved it recently.

Also, uncomment the `debug` method. I don't think it's a big problem to have it always uncommented, and it saves the hassle of uncommenting it whenever I am debugging something.

Also, add a test for the situation where I encountered this issue (since I thought there was a possibility that might be related to the problem). The test was passing even without any other changes, but I figure that we might as well add it, anyway.