### PR TITLE
Set up mitmproxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@ Brewfile.lock.json
 
 # Crystal shards
 /lib/
+
+# Feature flags
+/feature-flags/
+
+# mitmproxy config
+/mitmproxy.yml

--- a/bin/proxy_off
+++ b/bin/proxy_off
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Turn mitmproxy off.
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+rm -f "$HOME/code/dotfiles/feature-flags/mitmproxy"
+
+blue 'Proxy will be disabled at next login.'

--- a/bin/proxy_on
+++ b/bin/proxy_on
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Turn mitmproxy on (and then run `mitmdump` in a terminal).
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+touch "$HOME/code/dotfiles/feature-flags/mitmproxy"
+
+blue 'Proxy will be enabled at next login.'

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,8 @@
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
 mkdir -p ~/.config/
+mkdir -p ~/.mitmproxy/
+mkdir -p ~/code/dotfiles/feature-flags/
 
 ln -sf ~/code/dotfiles/aprc.rb ~/.config/aprc
 ln -sf ~/code/dotfiles/asdfrc ~/.asdfrc
@@ -12,11 +14,21 @@ ln -sf ~/code/dotfiles/git/gitconfig ~/.gitconfig
 ln -sf ~/code/dotfiles/git/global_gitignore ~/.gitignore
 ln -sf ~/code/dotfiles/irbrc.rb ~/.irbrc.rb
 ln -sf ~/code/dotfiles/kitty/ ~/.config/
+ln -sf ~/code/dotfiles/mitmproxy.yml ~/.mitmproxy/config.yaml
 ln -sf ~/code/dotfiles/pryrc.rb ~/.pryrc
 ln -sf ~/code/dotfiles/rspec ~/.rspec
 ln -sf ~/code/dotfiles/rubocop.yml ~/.rubocop.yml
 ln -sf ~/code/dotfiles/zsh/themes/bolso.zsh-theme ~/.oh-my-zsh/custom/themes/bolso.zsh-theme
 ln -sf ~/code/dotfiles/zshrc.zsh ~/.zshrc
+
+# Check whether it's worth making the user type in their password (i.e. if update is needed).
+mitmproxy_env_vars_source=~/code/dotfiles/mitmproxy_env.sh
+mitmproxy_env_vars_destination=/etc/X11/Xsession.d/90mitmproxy_env
+if [ ! -f "$mitmproxy_env_vars_destination" ] || \
+    ! diff -q "$mitmproxy_env_vars_source" "$mitmproxy_env_vars_destination" > /dev/null ;
+then
+  sudo ln -sf "$mitmproxy_env_vars_source" "$mitmproxy_env_vars_destination"
+fi
 
 if [ -e "$HOME/code/dotfiles-personal/install.sh" ]; then
   cd "$HOME/code/dotfiles-personal/"

--- a/mitmproxy_env.sh
+++ b/mitmproxy_env.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+if [ -f "$HOME/code/dotfiles/feature-flags/mitmproxy" ] ; then
+  mitmproxy_address="http://127.0.0.1:8080"
+
+  # http/https/ftp/no_proxy
+  export http_proxy="$mitmproxy_address"
+  export https_proxy="$mitmproxy_address"
+  # export ftp_proxy="$mitmproxy_address"
+  # export no_proxy="127.0.0.1,localhost"
+
+  # For curl
+  export HTTP_PROXY="$mitmproxy_address"
+  export HTTPS_PROXY="$mitmproxy_address"
+  # export FTP_PROXY="$mitmproxy_address"
+  # export NO_PROXY="127.0.0.1,localhost"
+fi

--- a/zshrc.zsh
+++ b/zshrc.zsh
@@ -101,6 +101,7 @@ path=(
   $HOME/code/dotfiles-personal/bin
   $HOME/code/dotfiles/bin
   $HOME/bin/crystal-symlinks
+  $HOME/bin
   $HOME/.local/bin
   node_modules/.bin
   # https://github.com/Homebrew/homebrew-core/issues/ 121043#issuecomment-1397888835


### PR DESCRIPTION
This has many different uses.

Today, I used it to delay the loading of the devicons CSS, to test this fix: #4921.

Another use is monitoring traffic from other applications/commands, such as VS Code or `bundle update`, which could reveal malicious requests or other interesting things.

To use: 1. `proxy_on` 2. log out and log back in 3. `mitmdump` 4. when done: `proxy_off`