### PR TITLE
[crystal] Set SHARDS_INSTALL_PATH via wrapper (not zshrc)

### DIFF
--- a/bin/shards
+++ b/bin/shards
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# This is a wrapper around `shards` to run it with a `SHARDS_INSTALL_PATH` in
+# `~/.shards` (not `./lib/`) for the current directory.
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+# Export a SHARDS_INSTALL_PATH for the current directory.
+SHARDS_INSTALL_PATH="$HOME/.shards/$(basename "$PWD")"
+export SHARDS_INSTALL_PATH
+
+# Invoke the original shards executable, forwarding all arguments.
+exec /usr/bin/shards "$@"

--- a/zshrc.zsh
+++ b/zshrc.zsh
@@ -91,7 +91,6 @@ fi
 export HOMEBREW_NO_AUTO_UPDATE=1
 
 # Crystal
-export SHARDS_INSTALL_PATH="$HOME/.shards/$(basename $PWD)"
 export CRYSTAL_PATH="$SHARDS_INSTALL_PATH:/usr/share/crystal/src"
 
 # Rust


### PR DESCRIPTION
The problem is that zshrc only runs at terminal startup (unless later manually sourced). So, if I `cd` into a different directory and run `shards install`, then, using the previous zshrc-based approach, the SHARDS_INSTALL_PATH would be outdated/wrong. This new approach ensures that `SHARDS_INSTALL_PATH` is set as desired for the current directory, even if the current directory is not the same directory as we were in when the terminal was started.