### PR TITLE
[merge-prs] Specify empty commit message body

### DIFF
--- a/bin/merge-prs
+++ b/bin/merge-prs
@@ -173,7 +173,7 @@ class GithubPrAutoMerger < CommandKit::Command
     client.merge_pull_request(
       { repo:, user: 'davidrunger' },
       pr.number,
-      pr.title, # commit message
+      '', # commit message body
       merge_method: 'squash',
     )
 


### PR DESCRIPTION
The commit message title seems to be created automatically based on the PR title. Previously, both the commit title and body were being created using the PR title. Now, we will have no commit message body (just a title).