### PR TITLE
[update-gems] Use 'test -f' instead of 'ls' to check for Gemfile.lock

### DIFF
--- a/tools/update-gems.sh
+++ b/tools/update-gems.sh
@@ -13,7 +13,7 @@ for dir in $(my-repos) ; do
   cd "$dir" || exit
   blue "# $dir"
 
-  if ls Gemfile.lock &>/dev/null ; then
+  if [ -f Gemfile.lock ] ; then
     if ! [[ "$dir" =~ ^(byebug|cuprite|fixture_builder|pallets|ransack)$ ]] ; then
       set -ex
 


### PR DESCRIPTION
It's more idiomatic, simple, more concise, and probably more performant to use 'test -f' to check for the existence of a file.