### PR TITLE
[update-gems] Exit with 1 on cd failure

### DIFF
--- a/tools/update-gems.sh
+++ b/tools/update-gems.sh
@@ -7,13 +7,13 @@
 
 set -uo pipefail # don't allow undefined variables, pipes don't swallow errors
 
-cd "$HOME/code" || exit
+cd "$HOME/code" || exit 1
 
 branch_name="bundle-update"
 ignore_dirs=$(runger-config --show forks | paste -sd '|' -)
 
 for dir in $(my-repos) ; do
-  cd "$dir" || exit
+  cd "$dir" || exit 1
   blue "# $dir"
 
   if [ -f Gemfile.lock ] && ! [[ "$dir" =~ ^(${ignore_dirs})$ ]] ; then
@@ -39,5 +39,5 @@ for dir in $(my-repos) ; do
 
   echo
 
-  cd - &>/dev/null || exit
+  cd - &>/dev/null || exit 1
 done


### PR DESCRIPTION
I don't really know how we could reach this code, but, if we somehow do, then it seems to me that we should exit with failure (1) rather than 0 (success).