### PR TITLE
Consolidate 'tc' and 'tf' into a new 'tally' script [DOT-81]

### DIFF
--- a/bin/tally
+++ b/bin/tally
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# [tally] the number of things in an input (read from stdin, a file, or clipboard).
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+input=""
+
+# File name provided.
+if [ $# -ne 0 ] ; then
+  input="$(cat "$1")"
+# Receiving piped stdin.
+elif [[ -p /dev/stdin ]] ; then
+  input="$(cat -)"
+# Pull from clipboard.
+else
+  input="$(pst)"
+fi
+
+echo "$input" | sort | uniq -c | sort -nr

--- a/bin/tc
+++ b/bin/tc
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-# [t]ally occurrences of distinct lines in [c]lipboard
-
-set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
-
-pst | sort | uniq -c | sort -nr

--- a/bin/tf
+++ b/bin/tf
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-# [t]ally occurrences of distinct lines in a [f]ile
-
-set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
-
-# Get input from file argument (if provided) or otherwise from stdin.
-sort < "${1:-/dev/stdin}" | uniq -c | sort -nr


### PR DESCRIPTION
I found the names `tc` and `tf` difficult to remember, especially since I don't use those commands super commonly (lately). `tally` will be much easier to remember. Also, in addition to the naming change/improvement, this DRYs up the code that was previously somewhat duplicated between the `tc` and `tf` scripts.