### PR TITLE
[lint/gitleaks] Update from deprecated 'detect' command to 'git'

### DIFF
--- a/bin-lint/gitleaks
+++ b/bin-lint/gitleaks
@@ -4,8 +4,8 @@
 
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
-if gitleaks detect --log-opts="origin/$(main-branch)..." &> /dev/null ; then
+if gitleaks git --log-opts="origin/$(main-branch)..." &> /dev/null ; then
   echo 'Gitleaks did not detect any committed secrets.'
 else
-  gitleaks detect --log-opts="origin/$(main-branch)..." --verbose
+  gitleaks git --log-opts="origin/$(main-branch)..." --verbose
 fi


### PR DESCRIPTION
I think that there is a bug with `detect` in at least the latest version (8.23.2) where it has stopped respecting the `--log-opts` option, and it seemed to be scanning the entire repository history. Switching from `gitleaks detect` to the new, not-deprecated `gitleaks git` command seems to avoid/fix that issue. And it's probably good, in general, anyway, to update to that non-deprecated command.