### PR TITLE
[runger-config] Fix argument handling without any flags

### DIFF
--- a/crystal-programs/runger-config.cr
+++ b/crystal-programs/runger-config.cr
@@ -147,6 +147,8 @@ class RungerConfig::Cli < Clim
           end
         elsif opts.edit_private
           runger_config.open_private_config_file(config_key)
+        else
+          runger_config.exit_and_maybe_print(config_key, silent: opts.silent)
         end
       else
         if opts.show


### PR DESCRIPTION
`runger-config javascript-watch-command` (when run in my `david_runger` repo) was printing nothing, whereas we want it to print [`bin/vite dev`][1]. This change fixes that.

[1]: https://github.com/davidrunger/david_runger/blob/b2cb83c3/.runger-config.yml/#L2