### PR TITLE
[runger-config] Perform "show" when no arg or flags are given

### DIFF
--- a/crystal-programs/runger-config.cr
+++ b/crystal-programs/runger-config.cr
@@ -151,12 +151,12 @@ class RungerConfig::Cli < Clim
           runger_config.exit_and_maybe_print(config_key, silent: opts.silent)
         end
       else
-        if opts.show
-          runger_config.print_config
-        elsif opts.edit
+        if opts.edit
           runger_config.open_public_config_file
         elsif opts.edit_private
           runger_config.open_private_config_file
+        else # either opts.show or simply no option or argument
+          runger_config.print_config
         end
       end
     end


### PR DESCRIPTION
https://chatgpt.com/share/67969800-8664-8007-883c-1d95f5ee5400

ChatGPT had this insight about what a CLI should do when run unadorned:

> tools with narrowly focused purposes tend to favor running a default command [...], while tools with broad functionality tend to show help

This makes sense, and because I think that `runger-config` is more of a "focused purpose" type of tool, I will have it perform a best guess (and idempotent) useful command when executed without any argument or flags.