### PR TITLE
[wait-for-gh-checks] Handle checks with 'ERROR' status

### DIFF
--- a/bin/wait-for-gh-checks
+++ b/bin/wait-for-gh-checks
@@ -101,10 +101,11 @@ class WaitForChecksRunner::LoopRunner
 
   # See `gh run list --help` for all possible statuses (I think).
   CANCELLED = 'CANCELLED'
+  ERROR = 'ERROR'
   FAILURE = 'FAILURE'
   IN_PROGRESS = 'IN_PROGRESS'
+  SKIPPED = 'SKIPPED'
   SUCCESS = 'SUCCESS'
-  ALL_STATUSES = [CANCELLED, FAILURE, IN_PROGRESS, SUCCESS].freeze
 
   def_delegators(
     :@runner,
@@ -192,7 +193,7 @@ class WaitForChecksRunner::LoopRunner
 
   memoize \
   def total_num_started_checks
-    check_status_counts.values_at(*ALL_STATUSES).sum
+    check_status_counts.reject { _1 == SKIPPED }.sum(&:last)
   end
 
   memoize \
@@ -201,6 +202,8 @@ class WaitForChecksRunner::LoopRunner
       'max time exceeded'
     elsif check_status_counts[FAILURE].positive?
       'tests failed'
+    elsif check_status_counts[ERROR].positive?
+      'tests errored'
     elsif check_status_counts[CANCELLED].positive?
       'tests cancelled'
     end


### PR DESCRIPTION
The status of the Percy check was `"ERROR"` after Percy detected a diff.

Also, tweak how we count `total_num_started_checks`. Instead of whitelisting statuses for inclusion in the count, we will now instead blacklist statuses that we don't want to include in the count. This seems to me slightly less likely to require maintenance/updates in the future. Today's change, with the old approach, would have necessitated adding `ERROR` to the `ALL_STATUSES` list. With this change, we can delete the `ALL_STATUSES` list and no longer need to maintain it. The `ALL_STATUSES` name was misleading, anyway. A more accurate name would have been `ALL_NON_SKIPPED_STATUSES` or some such.