### PR TITLE
[merge-prs] Don't sleep after merging last PR in each repo

### DIFF
--- a/bin/merge-prs
+++ b/bin/merge-prs
@@ -74,9 +74,12 @@ class GithubPrAutoMerger < CommandKit::Command
   def merge_dependabot_prs(repo)
     open_prs = fetch_dependabot_prs(repo)
 
-    open_prs&.each do |pr|
+    open_prs&.each_with_index do |pr, index|
       process_pr(repo, pr)
-      sleep(10) # Wait between PRs in the same repo
+
+      unless index == open_prs.size - 1
+        sleep(10) # Wait between PRs in the same repo
+      end
     rescue => error
       log_pr_merge_error(repo, pr, error)
     end


### PR DESCRIPTION
The sleeps are to allow dependabot time to check whether any other PRs need to be rebased and to update those PRs with a message indicating such. There is no point in waiting for that after merging the last PR, though, because there are no other PRs that we want to avoid merging prematurely by not giving dependabot time to do that.