### PR TITLE
[gfcob] Update local main branch (not just the origin/main remote)

### DIFF
--- a/bin/gfcob
+++ b/bin/gfcob
@@ -4,6 +4,6 @@
 
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
-gfb "$(main-branch)"
+update-main-branches
 git checkout -b "$1" "origin/$(main-branch)"
 install-packages-in-background


### PR DESCRIPTION
If there have been updates on the remote main branch that I don't have locally, and then I do `gfcob some-new-branch`, then the `origin/main` branch will be updated by `gfb "$(main-branch)"`, but `main` will not. So, `main` becomes "behind" it's upstream remote branch. This is annoying.

To avoid this, this change instead uses `update-main-branches`, which will both fetch the latest `origin/main` _and_ update the local `main` branch.