### PR TITLE
Move --quit-if-one-screen option to front of LESS

### DIFF
--- a/zshrc.zsh
+++ b/zshrc.zsh
@@ -127,7 +127,7 @@ export EDITOR=editor
 { ( symlink-crystal-programs >&3 & ) } 3>&1
 
 # less options
-export LESS='-Rj6 -X --quit-if-one-screen'
+export LESS='--quit-if-one-screen -Rj6 -X'
 export LESSHISTFILE=- # don't store less search history https://web.archive.org/web/20141129223918/http://linuxcommand.org/man_pages/less1.html
 
 # for SimpleCov::Formatter::Terminal


### PR DESCRIPTION
Reason: Ruby's OptionParser will try to append `Fe` to the LESS environment variable, if it's defined. When `--quit-if-one-screen` is at the end, this results in the error `There is no quit-if-one-screenFe option`. By moving the verbose `--quit-if-o`ne-screen` flag to the front and bringing `-X` to the back, that short form flag can be combined with the `-F` and `-e` options added by Ruby without issue.