### PR TITLE
[yic] Allow customizable JavaScript install command via runger-config

### DIFF
--- a/bin/yic
+++ b/bin/yic
@@ -5,7 +5,9 @@
 
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
-if [ -f yarn.lock ] ; then
+if runger-config --silent javascript-install-command ; then
+  bash <<< "$(runger-config javascript-install-command)"
+elif [ -f yarn.lock ] ; then
   yarn install --check-files
 elif [ -f pnpm-lock.yaml ] ; then
   pnpm install --frozen-lockfile


### PR DESCRIPTION
This is helpful, for example, when working in a project like https://github.com/manyfold3d/manyfold , which uses yarn@3.8.5 , which does not support the `--check-files` option (and errors if it is used).