### PR TITLE
[rebase-branch-with-remote] Remove check for no uncommitted changes

### DIFF
--- a/bin/gfcob
+++ b/bin/gfcob
@@ -4,30 +4,6 @@
 
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
-unstaged_changes=0
-staged_changes=0
-
-if unstaged-changes-exist ; then
-  unstaged_changes=1
-  gstash
-fi
-
-if staged-changes-exist ; then
-  staged_changes=1
-  gunstage
-  gstash
-fi
-
 update-main-branches
 git checkout -b "$1" "origin/$(main-branch)"
-
-if [ $staged_changes = 1 ] ; then
-  gunstash
-  ga .
-fi
-
-if [ $unstaged_changes = 1 ] ; then
-  gunstash
-fi
-
 install-packages-in-background

--- a/bin/rebase-branch-with-remote
+++ b/bin/rebase-branch-with-remote
@@ -10,11 +10,6 @@ set -euo pipefail # exit on any error, don't allow undefined variables, pipes do
 local_branch="$1"
 remote_branch="$2"
 
-if uncommitted-changes-exist ; then
-  red "Refusing to rebase '$local_branch' with '$remote_branch' because of uncommitted changes."
-  exit 1
-fi
-
 original_branch="$(branch)"
 git checkout --quiet "$local_branch"
 


### PR DESCRIPTION
I'm not sure why I have this?, and I don't think it provides much benefit. It added a lot of complexity to `gfcob`, which I'm able to remove with this PR. But even those complexities didn't handle all situations, such as when a new file is being created (which doesn't get stashed and so which still ends up blocking the rebase).