### PR TITLE
[rrp] Add 'rspec' to processes_to_int

### DIFF
--- a/bin/rrp
+++ b/bin/rrp
@@ -7,7 +7,7 @@ processes_to_ignore="e?grep|Slack|Postman|GitHub|rubocop|open-pr-in-browser|Help
 |esbuild.*linux.*ping|wait-for-gh-checks|fusermount3|inode_switch_wbs|ruby/gems"
 processes_to_quit='ruby'
 processes_to_term='spring'
-processes_to_int='puma|sidekiq'
+processes_to_int='puma|sidekiq|rspec'
 
 stop_processes() {
   # only try to stop spring with `spring stop` if in a directory with a Gemfile that contains


### PR DESCRIPTION
I'm surprised that I didn't have it here already? Recently, a lingering RSpec process was remaining bound to port 3001. Adding rspec to this list and running `rp` killed it and freed the port for reuse.