### PR TITLE
[stack-trace-viewer] Ignore leading whitespace

### DIFF
--- a/bin/stack-trace-viewer
+++ b/bin/stack-trace-viewer
@@ -27,7 +27,7 @@ def print_context_for_line(line, stack_trace_order_number)
     return
   end
 
-  match = line.match(/^(.+):(\d+):in/)
+  match = line.match(/^\s*(\S+):(\d+):in/)
   return unless match
 
   file_path = match[1]


### PR DESCRIPTION
This is helpful because sometimes a stack trace will be printed with leading whitespace.