### PR TITLE
[stack-trace-viewer] Handle commented out (hashtag prefixed) lines

### DIFF
--- a/bin/stack-trace-viewer
+++ b/bin/stack-trace-viewer
@@ -27,7 +27,7 @@ def print_context_for_line(line, stack_trace_order_number)
     return
   end
 
-  match = line.match(/^\s*(\S+):(\d+):in/)
+  match = line.match(/^[\s#]*(\S+):(\d+):in/)
   return unless match
 
   file_path = match[1]


### PR DESCRIPTION
RSpec prints the backtrace lines with hashtags at the beginning. (I'm not sure why?) It looks like this:

With this change, we will be able to handle suck "commented out" stack traces with `stack-trace-viewer`.