### PR TITLE
[stack-trace-viewer] Print code in reverse of stack trace [DOT-87]

### DIFF
--- a/bin/stack-trace-viewer
+++ b/bin/stack-trace-viewer
@@ -61,8 +61,10 @@ end
 stack_trace = ARGV[0] ? File.read(ARGV[0]) : STDIN.read
 
 # Process each line of the stack trace
-stack_trace.each_line.with_index do |line, index|
+stack_trace_lines = stack_trace.lines
+
+stack_trace_lines.reverse.each_with_index do |line, index|
   next if line.strip.empty?
 
-  print_context_for_line(line, index + 1)
+  print_context_for_line(line, stack_trace_lines.size - index)
 end


### PR DESCRIPTION
Ruby prints the most recently called line at the top. When `stack-trace-viewer` also prints the code context of the stack trace in this same order, then I have to scroll all the way back up (which is sometimes pretty far) to view the "top" lines of the stack trace, which are usually the lines of greatest interest. Therefore, instead, this change prints the more recently called lines last, rather than first. Thus, the code of the most recently called lines will be visible without needing to scroll.