### PR TITLE
[gfco] Update main branches

### DIFF
--- a/bin/gfco
+++ b/bin/gfco
@@ -6,6 +6,7 @@ set -euo pipefail # exit on any error, don't allow undefined variables, pipes do
 
 branch=$1
 
+update-main-branch
 gfb "$branch"
 gco "$branch"
 gsup


### PR DESCRIPTION
When I check out a dependabot PR after merging a bunch of other dependabot PRs, if I don't update the main branch first, then the dependabot PR will appear as being many commits ahead of the upstream (`origin/main`), because my local `origin/main` won't have most of the recently merged updates. I would rather that the just-checked-out dependabot PR reflects its status relative to the latest version of `origin/main` on the remote (i.e. probably being just one commit ahead), and maybe some number of commits behind if dependabot hasn't rebased recently enough.

This change (calling `update-main-branch` at the beginning of `gfco`) will accomplish this goal.