### PR TITLE
[stack-trace-viewer] Handle reading from stdin without file argument

### DIFF
--- a/bin/stack-trace-viewer
+++ b/bin/stack-trace-viewer
@@ -52,7 +52,7 @@ class StackTraceViewer < CommandKit::Command
     desc: 'File containing stack trace.',
   )
 
-  def run(file)
+  def run(file = nil)
     @file = file
 
     stack_trace_lines.reverse.each_with_index do |line, index|


### PR DESCRIPTION
With this change, we can now do stuff like `pst | stack-trace-viewer`. Before, that would cause an error about the wrong number of arguments being provided to `run` (expected 1, got 0).