### PR TITLE
[kitty] Tweak theme in new theme-tweaks.conf (not current-theme.conf)

### DIFF
--- a/kitty/current-theme.conf
+++ b/kitty/current-theme.conf
@@ -8,7 +8,7 @@
 
 # The basic colors
 foreground              #ffffff
-background              #030306
+background              #000000
 selection_foreground    #ffffff
 selection_background    #5c5c5c
 

--- a/kitty/kitty.conf
+++ b/kitty/kitty.conf
@@ -30,4 +30,6 @@ map ctrl+s kitten hints --customize-processing kitty_opener.py
 include current-theme.conf
 # END_KITTY_THEME
 
+include theme-tweaks.conf
+
 include kitty_${KITTY_OS}.conf

--- a/kitty/theme-tweaks.conf
+++ b/kitty/theme-tweaks.conf
@@ -1,0 +1,1 @@
+background #030306


### PR DESCRIPTION
I think that current-theme.conf is managed by some kitty theme-picker tool, so I think I probably shouldn't change that. I am guessing that my customizations would be overridden, if I were ever to use that theme-picking tool again. By putting my theme tweak in a separate file (loaded after `current-theme.conf`), my customizations will still take effect, even if current-theme.conf is changed/reverted by the kitty theme-picking tool.