### PR TITLE
[check-git-push-readiness] Check for 'debug.rb' [DOT-90]

### DIFF
--- a/bin/check-git-push-readiness
+++ b/bin/check-git-push-readiness
@@ -40,7 +40,7 @@ fi
 debugging_code_regex_parts=(
   '^((\s*|RSpec\.)(fit|fdescribe|fcontext|fscenario|fspecify))|'
   '(^\s*[^#]*|["'"'"'].*)\b(open_page|save_and_open_page)\b|'
-  '\b(binding\.pry|byebug|debugger)\b|'
+  '\b(binding\.pry|byebug|debugger|debug\.rb)\b|'
   '\btapp\b'
 )
 


### PR DESCRIPTION
I often load `utils/ruby/debug.rb` from this repo into a Ruby project that I want to debug, but I should remove that load statement before pushing.