### PR TITLE
Omit PR description from commit message for dependabot PRs [DOT-92]

### DIFF
--- a/bin/wait-merge
+++ b/bin/wait-merge
@@ -17,7 +17,14 @@ if uncommitted-changes-exist ; then
 fi
 
 wait-for-gh-checks "$gh_check_branch"
-gh pr merge "$gh_check_branch" --squash
+
+if [[ "$gh_check_branch" =~ ^dependabot/ ]] ; then
+  # Omit the verbose PR description as the commit body for Dependabot PRs.
+  gh pr merge "$gh_check_branch" --squash --body ''
+else
+  gh pr merge "$gh_check_branch" --squash
+fi
+
 say "P R merged"
 
 # switch to main branch if still on the local branch that was just merged


### PR DESCRIPTION
Sometimes, I check out and iterate on a Dependabot PR, and then I ultimately merge that PR via `wait-merge`. It would be nice if, in these situations, `wait-merge` would not merge the PR description as the commit body. (Note: we already do this in `merge-prs`.) This change implements that functionality.