### PR TITLE
[gal/sidekiq] Remove frozen_string_literal comment

### DIFF
--- a/bin/gal
+++ b/bin/gal
@@ -101,9 +101,6 @@ class Runner
     },
     sidekiq: {
       path: 'personal/runner.rb',
-      content: <<~RUBY,
-        # frozen_string_literal: true
-      RUBY
     },
     sql: {
       path: 'personal/sql.sql',


### PR DESCRIPTION
This is not needed in the `david_runger` repo, now that we are using freezolite. (I confirmed experimentally that modifying a string literal in `personal/runner.rb` raises an error.) As such, it just creates an annoyance, because if I have the file completely empty, then `gal` asks if the file content is okay. We want empty file content to be the default, so that such confirmation is not required.