### PR TITLE
[rrp] Don't kill nodetach processes

### DIFF
--- a/bin/rrp
+++ b/bin/rrp
@@ -4,7 +4,8 @@
 
 processes_to_ignore="e?grep|Slack|Postman|GitHub|rubocop|open-pr-in-browser|Helper|\bbrew\b\
 |solargraph|ionodecache|ruby-lsp|fuzzy-ruby-server|node-ipc|node.mojom|code.*extensions\
-|esbuild.*linux.*ping|wait-for-gh-checks|merge-prs|fusermount3|inode_switch_wbs|ruby/gems"
+|esbuild.*linux.*ping|wait-for-gh-checks|merge-prs|fusermount3|inode_switch_wbs|ruby/gems\
+|nodetach"
 processes_to_quit='ruby'
 processes_to_term='spring'
 processes_to_int='puma|sidekiq|rspec'


### PR DESCRIPTION
There was a process like `xsel --nodetach` or something. We don't want to kill that. (It was being matched because of "node".)