### PR TITLE
[stack-trace-viewer] Handle lines that start with 'from '

### DIFF
--- a/bin/stack-trace-viewer
+++ b/bin/stack-trace-viewer
@@ -13,6 +13,7 @@
 # Stack traces should have a format like this:
 #     /home/david/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/rspec-mocks-3.13.2/lib/rspec/mocks/message_expectation.rb:762:in 'block in RSpec::Mocks::Implementation#call'
 #     /home/david/code/david_runger/config/initializers/error_subscriber.rb:35:in 'Kernel#public_send'
+#     from /app/vendor/bundle/ruby/3.4.0/bundler/gems/typelizer-147c27dea7de/lib/typelizer/interface.rb:79:in 'Typelizer::Interface#infer_types'
 #     <internal:kernel>:168:in 'Kernel#loop'
 #     bin/rspec:17:in 'Kernel#load'
 # rubocop:enable Layout/LineLength
@@ -99,7 +100,7 @@ class StackTraceViewer < CommandKit::Command
       return
     end
 
-    match = line.match(/^[\s#]*(\S+):(\d+):in/)
+    match = line.match(/^\s*(?:#|from)\s*(\S+):(\d+):in/)
 
     if !match
       return


### PR DESCRIPTION
I'm not sure why some stack traces have 'from ' at the beginning of the lines, but some do. This change updates the regex to handle such lines.