### PR TITLE
[aliases] Add '--binary' option to 'eza' 'ls' alias

### DIFF
--- a/shell/aliases.zsh
+++ b/shell/aliases.zsh
@@ -45,7 +45,7 @@ alias gsf='git show $(active-branches | fzf)'
 alias gsl='git show -s --format=%s'
 alias hwm='hpr && echo && wm'
 alias hwm='hpr && echo && wm'
-alias ls='eza'
+alias ls='eza --binary'
 alias md='mkdir -p'
 alias mdm='main && gdm && echo "----" && gb'
 alias rc="bin/rails console"


### PR DESCRIPTION
By default, units are I think "k" and "M" meaning I think 1,000 and 1,000,000. Using the '--binary' flag makes units I think "Ki" and "Mi", i.e. 1,024 and 1,048,576 bytes, which is what I expect and which is less ambiguous.