### PR TITLE
[update-gems] Commit to main to avoid running 'bundle update' twice

### DIFF
--- a/tools/update-gems.sh
+++ b/tools/update-gems.sh
@@ -24,12 +24,12 @@ for dir in $(my-repos) ; do
       bundle update
 
       if ! git diff --quiet ; then
-        gclean
-        gfcob "$branch_name"
-        bundle update
         gacm "Update gems
 
 \`bundle update\`"
+        gfcob "$branch_name"
+        gcp main
+        git branch --force main origin/main
         hpr
       fi
     fi


### PR DESCRIPTION
We'll commit to main, check out a bundle-update branch, cherry pick the commit from main, and reset main to origin/main.