### PR TITLE
[update-gems] Use git commands directly (not 'gacm') to skip check

### DIFF
--- a/tools/update-gems.sh
+++ b/tools/update-gems.sh
@@ -24,7 +24,8 @@ for dir in $(my-repos) ; do
       bundle update
 
       if ! git diff --quiet ; then
-        gacm "Update gems
+        git add .
+        git commit --message "Update gems
 
 \`bundle update\`"
         gfcob "$branch_name"


### PR DESCRIPTION
`gacm` runs `verify-on-ok-branch` to check that we aren't on the primary branch, but, when executing this command, we will be on the primary branch. We'll skip that check by using `git add .` and `git commit
--message` directly.