### PR TITLE
Move from asdf to mise for node version management

### DIFF
--- a/asdfrc
+++ b/asdfrc
@@ -1,1 +1,0 @@
-legacy_version_file = yes

--- a/install.sh
+++ b/install.sh
@@ -7,13 +7,13 @@ mkdir -p ~/.mitmproxy/
 mkdir -p ~/code/dotfiles/feature-flags/
 
 ln -sf ~/code/dotfiles/aprc.rb ~/.config/aprc
-ln -sf ~/code/dotfiles/asdfrc ~/.asdfrc
 ln -sf ~/code/dotfiles/cheat/ ~/.config/
 ln -sf ~/code/dotfiles/gemrc.yml ~/.gemrc
 ln -sf ~/code/dotfiles/git/gitconfig ~/.gitconfig
 ln -sf ~/code/dotfiles/git/global_gitignore ~/.gitignore
 ln -sf ~/code/dotfiles/irbrc.rb ~/.irbrc.rb
 ln -sf ~/code/dotfiles/kitty/ ~/.config/
+ln -sf ~/code/dotfiles/mise.toml ~/.config/mise/config.toml
 ln -sf ~/code/dotfiles/mitmproxy.yml ~/.mitmproxy/config.yaml
 ln -sf ~/code/dotfiles/pryrc.rb ~/.pryrc
 ln -sf ~/code/dotfiles/rspec ~/.rspec

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,5 @@
+[settings]
+activate_aggressive = true
+
+[tools]
+node = "22.14.0"

--- a/zshrc.zsh
+++ b/zshrc.zsh
@@ -13,7 +13,6 @@ fi
 # Look for zsh completion definitions in dotfiles/completions/ directory.
 # NOTE: This must come before loading oh-my-zsh.
 fpath=(~/code/dotfiles/completions $fpath)
-fpath=(~/.asdf/completions $fpath)
 
 # zsh/oh-my-zsh
 # NOTE: must come after sourcing linux.zsh, so that git is available via Homebrew for update check.
@@ -109,11 +108,6 @@ path=(
   $path
 )
 
-# asdf setup (needs to be below path setup)
-if [ -d "$HOME/.asdf/" ]; then
-  export PATH="$HOME/.asdf/shims:$PATH"
-fi
-
 if [ -v LINUX ] ; then
   path=($HOME/code/dotfiles/bin-linux $path)
 else if [ -v DARWIN ]
@@ -144,3 +138,6 @@ export SAVEHIST="$HISTSIZE"
 # Atuin (https://github.com/atuinsh/atuin)
 . "$HOME/.atuin/bin/env"
 eval "$(atuin init zsh --disable-up-arrow)"
+
+# Mise
+eval "$(mise activate zsh)"


### PR DESCRIPTION
`brew install mise`

I have been having some issues with asdf/pnpm (where the pnpm version regresses from version 10 to version 9 and where I have to run `asdf reshim pnpm` to activate the latest version) that I am hoping will be resolved by mise.