### PR TITLE
[mise] Warn always on missing tools

### DIFF
--- a/mise.source.toml
+++ b/mise.source.toml
@@ -1,5 +1,9 @@
 [settings]
 activate_aggressive = true
+disable_tools = ["ruby"]
+
+[settings.status]
+missing_tools = "always"
 
 [tools]
 node = "22.14.0"


### PR DESCRIPTION
... except for ruby, which I manage using trusty rbenv.

(The default is to warn only `if_other_versions_installed`.)