### PR TITLE
[zshrc] Add back pnpm stuff

### DIFF
--- a/zshrc.zsh
+++ b/zshrc.zsh
@@ -59,8 +59,15 @@ if command -v yarn &> /dev/null ; then
   export PATH=$PATH:$(yarn global bin)
 fi
 
+# pnpm setup on Linux
+if [ -d "$HOME/.local/share/pnpm" ]; then
+  export PNPM_HOME="$HOME/.local/share/pnpm"
+  case ":$PATH:" in
+    *":$PNPM_HOME:"*) ;;
+    *) export PATH="$PNPM_HOME:$PATH" ;;
+  esac
 # pnpm setup on MacOS
-if [ -d "$HOME/Library/pnpm" ]; then
+elif [ -d "$HOME/Library/pnpm" ]; then
   export PNPM_HOME="$HOME/Library/pnpm"
   case ":$PATH:" in
     *":$PNPM_HOME:"*) ;;


### PR DESCRIPTION
I removed this in #541, but apparently I shouldn't have. I saw this warning:

```
❯ pnpm add --global http-server live-server prettier typescript tsx
 ERR_PNPM_NO_GLOBAL_BIN_DIR  Unable to find the global bin directory

Run "pnpm setup" to create it automatically, or set the global-bin-dir setting, or the PNPM_HOME env variable. The global bin directory should be in the PATH.
```

Running the suggested `pnpm setup` command added this stuff to my zshrc (modulo some slight tweaks by me).