### PR TITLE
[update-npm-packages] Use 'yarn upgrade --latest'

### DIFF
--- a/tools/update-npm-packages.sh
+++ b/tools/update-npm-packages.sh
@@ -44,7 +44,7 @@ for dir in $(my-repos) ; do
       if [ -f pnpm-lock.yaml ]; then
         update_and_create_pr "pnpm update && pnpm dedupe"
       elif [ -f yarn.lock ]; then
-        update_and_create_pr "yarn upgrade && pnpx yarn-deduplicate yarn.lock"
+        update_and_create_pr "yarn upgrade --latest && pnpx yarn-deduplicate yarn.lock"
       fi
     fi
 


### PR DESCRIPTION
This updates `package.json` in addition to `yarn.lock` (and also will go beyond the version constraints specified in `yarn.lock`, I think, which was not initially my primary goal with this change, but which is also probably good).