### PR TITLE
[update-npm-packages] Use '--latest' flag for 'pnpm update' command

### DIFF
--- a/tools/update-npm-packages.sh
+++ b/tools/update-npm-packages.sh
@@ -42,7 +42,7 @@ for dir in $(my-repos) ; do
 
     if git diff --quiet && ! branch-exists "$branch_name" ; then
       if [ -f pnpm-lock.yaml ]; then
-        update_and_create_pr "pnpm update && pnpm dedupe"
+        update_and_create_pr "pnpm update --latest && pnpm dedupe"
       elif [ -f yarn.lock ]; then
         update_and_create_pr "yarn upgrade --latest && pnpx yarn-deduplicate yarn.lock"
       fi


### PR DESCRIPTION
This will ignore version restrictions in `package.json`, which I think that I generally want (so that we can, for example, move to a new major version, if when `package.json` has something like `"ky": "^1.7.5"`).