### PR TITLE
[merge-prs] Print "Done fetching [...]" message in cyan

### DIFF
--- a/bin/merge-prs
+++ b/bin/merge-prs
@@ -125,7 +125,7 @@ class GithubPrAutoMerger < CommandKit::Command
       log_verbose("Fetching PRs for #{@repo}")
 
       @client.pull_requests(repo_hash, author: 'dependabot', state: 'open').tap do
-        log_verbose("Done fetching PRs for #{@repo}".green)
+        log_verbose("Done fetching PRs for #{@repo}".cyan)
       end
     end
 


### PR DESCRIPTION
This leaves green to be a special color that is only used to print when a PR has been merged, helping those log lines to stand out more.