### PR TITLE
[github-stars-explorer] Allow exploring specific repo(s) [DOT-96]

### DIFF
--- a/tools/github-stars-explorer.ts
+++ b/tools/github-stars-explorer.ts
@@ -254,10 +254,16 @@ class GitHubStarAnalyzer {
   ): Promise<void> {
     const allMyStarredReposArray = await this.getAllStarredRepos(username);
     this.allMyStarredReposSet = new Set(allMyStarredReposArray);
-    const myReposToAnalyze = allMyStarredReposArray.slice(
-      0,
-      numberOfMyReposToLookAt,
-    );
+    let myReposToAnalyze;
+
+    if (process.env.REPOS_TO_EXPLORE) {
+      myReposToAnalyze = process.env.REPOS_TO_EXPLORE.split(',');
+    } else {
+      myReposToAnalyze = allMyStarredReposArray.slice(
+        0,
+        numberOfMyReposToLookAt,
+      );
+    }
 
     console.log(`Found ${allMyStarredReposArray.length} total starred repos.`);
     console.log(
@@ -372,6 +378,15 @@ async function main() {
   }
 
   const analyzer = new GitHubStarAnalyzer(token);
+
+  if (
+    process.env.NUMBER_OF_MY_REPOS_TO_LOOK_AT &&
+    process.env.REPOS_TO_EXPLORE
+  ) {
+    console.warn(
+      'Warning: NUMBER_OF_MY_REPOS_TO_LOOK_AT is ignored when REPOS_TO_EXPLORE is present.',
+    );
+  }
 
   const numberOfMyReposToLookAt = parseInt(
     process.env.NUMBER_OF_MY_REPOS_TO_LOOK_AT || '2',


### PR DESCRIPTION
I found the results pretty interesting when doing this for `laserlemon/rspec-wait` (by just temporarily modifying the source code to only use that repo). It might be useful to make it easier to explore the stars of the stargazers of other specific repos. It sort of seems like I get a better signal from somewhat lesser starred repos (which `laserlemon/rspec-wait` is an example of). I think that this is because it probably takes a little more taste and discernment to star a lesser known repo, so those stargazers have relatively better taste, on average.

This change implements support for exploring specific repo(s) via a `REPOS_TO_EXPLORE` env var.