### PR TITLE
[my-github-stars] Support sourcing data from a file [DOT-101]

### DIFF
--- a/tools/my-github-stars.ts
+++ b/tools/my-github-stars.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'fs';
 import ky from 'ky';
 
 interface LanguageEdge {
@@ -63,6 +64,10 @@ function formatLanguageBreakdown(
 async function fetchAllStarredRepos(
   username: string,
 ): Promise<{ repo: Repository; starredAt: string }[]> {
+  if (process.env.STARS_DATA_FILE_PATH) {
+    return JSON.parse(readFileSync(process.env.STARS_DATA_FILE_PATH, 'utf8'));
+  }
+
   let hasNextPage = true;
   let endCursor: string | null = null;
   const allStarredRepos: { repo: Repository; starredAt: string }[] = [];


### PR DESCRIPTION
This will be useful for developing/testing functionality just related to formatting the output, without the incurring the slowness, rate limiting, and general wastefulness and minor ethical concerns of unnecessarily hitting the live GitHub GraphQL API.

Example usage: `STARS_DATA_FILE_PATH=personal/json.json tsx
--env-file=.env tools/my-github-stars.ts`