### PR TITLE
[my-github-stars] Handle possibility of null language color

### DIFF
--- a/tools/my-github-stars.ts
+++ b/tools/my-github-stars.ts
@@ -56,7 +56,7 @@ function formatLanguageBreakdown(
     .sort((a, b) => b.size - a.size)
     .map(
       ({ node, size }) =>
-        `${chalk.hex(node.color)('██')} ${node.name} (${((size / totalSize) * 100).toFixed(1)}%)`,
+        `${chalk.hex(node.color || '#555')('██')} ${node.name} (${((size / totalSize) * 100).toFixed(1)}%)`,
     )
     .join(', ');
 }


### PR DESCRIPTION
For example, "Rich Text Format" (a language of `grafana/grafana`) has a `null` color. We'll just use a gray color, in that case.