### PR TITLE
[gal] Remove parenthetical description of 'ptest' from '--help'

### DIFF
--- a/bin/gal
+++ b/bin/gal
@@ -54,8 +54,7 @@ opts =
       '-g',
       '--guardfile',
       "guardfile flag [#{Gal.guardfile_types.join('|')}]".
-        sub(/\bspec\b/, 'spec(default)').
-        sub(/\bptest\b/, 'ptest(Python unittest)'),
+        sub(/\bspec\b/, 'spec(default)'),
     )
     o.string('-t', '--target', 'jest target pattern')
     o.string('--coverage-target', 'specify SIMPLECOV_TARGET_FILE')


### PR DESCRIPTION
It's not really necessary. I am the only person who uses this tool, and I know what it means. I think that the clutter is not worthwhile. Also, now we have `ctest`, so we should probably have parenthetical descriptions for both `ctest` and `ptest` or neither. I think having it for both is too much / too verbose, so this change goes with neither.