### PR TITLE
[active-branches] Handle regex characters (e.g. '+') in branch names

### DIFF
--- a/bin/active-branches
+++ b/bin/active-branches
@@ -6,4 +6,4 @@
 # - branches prefixed with `z-`
 
 git for-each-ref --format="%(refname:short)" refs/heads | \
-  rg -v "^($(main-branch)|$(branch))$|^z-"
+  awk '!($0 == main || $0 == branch || $0 ~ /^z-/)' main="$(main-branch)" branch="$(branch)"


### PR DESCRIPTION
... by using `awk` rather than `rg`.

https://x.com/i/grok?conversation=1901883837128364255

This fixes a bug. When I was on a branch called `avoid-n+1-queries-in-version_limit-when-destroying`, `gc` (which uses `active-branches`) was giving me the current branch (`avoid-n+1-queries-in-version_limit-when-destroying`) as an option to switch to, because the `+` character in the branch name was being interpreted as a regex metacharacter, rather than being essentially interpreted literally. So, that current branch wasn't being excluded from the `active-branches` list. This change fixes the issue by just using `awk` in such a way that we don't need to worry about escaping the current branch name as a regex and instead we can just check for equality directly.