### PR TITLE
[update-npm-packages] Use npm-check-updates for pnpm repos

### DIFF
--- a/tools/update-npm-packages.sh
+++ b/tools/update-npm-packages.sh
@@ -42,7 +42,7 @@ for dir in $(my-repos) ; do
 
     if git diff --quiet && ! branch-exists "$branch_name" ; then
       if [ -f pnpm-lock.yaml ]; then
-        update_and_create_pr "pnpm update --latest && pnpm dedupe"
+        update_and_create_pr "pnpx npm-check-updates --upgrade && pnpm install && pnpm dedupe"
       elif [ -f yarn.lock ]; then
         update_and_create_pr "yarn upgrade --latest && pnpx yarn-deduplicate yarn.lock"
       fi


### PR DESCRIPTION
https://x.com/i/grok?conversation=1901911782148460993

The problem with `pnpm update --latest` is that it will use alpha versions, which I don't really want.

`npm-check-updates` will bump across major versions (which I want) but it won't use alpha versions (which I don't want to use), so it's perfect.

Side note: the `--interactive` flag is pretty nice to use, but not applicable here, I guess.