### PR TITLE
[global_gitignore] Ignore 'personal/' directories nested 1 level deep

### DIFF
--- a/git/global_gitignore
+++ b/git/global_gitignore
@@ -14,6 +14,7 @@
 # Personal stuff and customization
 .runger-config.private.yml
 /personal/
+/*/personal/
 config/initializers/z.rb
 app/workers/load_runner.rb
 


### PR DESCRIPTION
This can be useful in a monorepo where e.g. we might run specs with `gal` in a nested directory rather than the root directory.