### PR TITLE
[ripgrep] Add ripgrep configuration file

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,7 @@ ln -sf ~/code/dotfiles/kitty/ ~/.config/
 ln -sf ~/code/dotfiles/mise.source.toml ~/.config/mise/config.toml
 ln -sf ~/code/dotfiles/mitmproxy.yml ~/.mitmproxy/config.yaml
 ln -sf ~/code/dotfiles/pryrc.rb ~/.pryrc
+ln -sf ~/code/dotfiles/ripgrep ~/.config/ripgrep
 ln -sf ~/code/dotfiles/rspec ~/.rspec
 ln -sf ~/code/dotfiles/zsh/themes/bolso.zsh-theme ~/.oh-my-zsh/custom/themes/bolso.zsh-theme
 ln -sf ~/code/dotfiles/zshrc.zsh ~/.zshrc

--- a/ripgrep
+++ b/ripgrep
@@ -1,0 +1,1 @@
+--hyperlink-format=kitty

--- a/zshrc.zsh
+++ b/zshrc.zsh
@@ -142,3 +142,6 @@ eval "$(atuin init zsh --disable-up-arrow)"
 
 # Mise
 eval "$(mise activate zsh)"
+
+# ripgrep
+export RIPGREP_CONFIG_PATH="$HOME/.config/ripgrep"


### PR DESCRIPTION
https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md#configuration-file

Note:

> ripgrep will not look in any predetermined directory for a config file automatically. Instead, you need to set the `RIPGREP_CONFIG_PATH` environment variable to the file path of your config file.

That's why we are setting `RIPGREP_CONFIG_PATH` in the zshrc.