### PR TITLE
[gitconfig/delta] Set 'wrap-max-lines = 40'

### DIFF
--- a/git/gitconfig
+++ b/git/gitconfig
@@ -6,6 +6,7 @@
   light = false
   navigate = true    # use n and N to move between diff sections
   side-by-side = true
+  wrap-max-lines = 40
 [diff]
   algorithm = histogram
   colorMoved = default


### PR DESCRIPTION
https://dandavison.github.io/delta/side-by-side-view.html

This will avoid truncating most lines, even long ones. Only really long lines (that come out to more than 40 lines in the right-hand side of the `delta` view, I think) will be wrapped. Now, most lines will be wrapped onto up to 40 broken up lines in `delta` (so we don't have to bother doing that in the code itself).

Per https://dandavison.github.io/delta/full---help-output.html , the default value is just `2`, so bumping to `40` is a significant increase.

The motivation for this is that I want to stop hard-wrapping paragraphs etc in Pug templates (and maybe Haml templates). For example, see https://github.com/davidrunger/david_runger/pull/6477 .