### PR TITLE
[upload-png-to-s3] Add script to upload a PNG to S3

### DIFF
--- a/bin/upload-png-to-s3
+++ b/bin/upload-png-to-s3
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# [upload] a [png] [to] [s3]
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+png_file_name="$1"
+
+# Exit with 1 if png_file_name includes a slash (i.e. it's a path rather than just a file).
+if [[ "$png_file_name" == */* ]]; then
+    echo "Error: File name should not include a path. Please provide just the file name."
+    exit 1
+fi
+
+# Upload file to S3 with all metadata set in a single command
+aws s3 cp "$png_file_name" "s3://david-runger-public-uploads/$png_file_name" \
+    --metadata-directive REPLACE \
+    --cache-control "max-age=60,public" \
+    --content-disposition "inline" \
+    --content-type "image/png"


### PR DESCRIPTION
I think that I'm going to increasingly host my app's images on S3 rather than in the git repo. To this end, I want to make it easy to upload images. For now, I'll start with this PNG-specific uploader. It's PNG-specific because of the `Content-Type` response header that it sets.