### PR TITLE
[merge-prs] Print the title of failing PRs

### DIFF
--- a/bin/merge-prs
+++ b/bin/merge-prs
@@ -208,7 +208,7 @@ class GithubPrAutoMerger < CommandKit::Command
         if unskipped_statuses_and_conclusions.all?('success')
           return true
         elsif unskipped_statuses_and_conclusions.include?('failure')
-          puts("Failing GitHub Actions for PR ##{@pr.number} in #{@repo}".red)
+          puts("Failing GitHub Actions for PR ##{@pr.number} in #{@repo} - #{@pr.title}".red)
           return false
         end
 


### PR DESCRIPTION
We print the title when merging a PR whose checks have successfully passed. Let's also print the title for failing PRs. This will be useful context.