### PR TITLE
[use-strict-git-rules] Use strict git rules by default

### DIFF
--- a/bin/use-strict-git-rules
+++ b/bin/use-strict-git-rules
@@ -4,4 +4,4 @@
 
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
-[[ $PWD == "$HOME/code/a_workplace_codebase" ]] && branch-exists-on-remote
+! runger-config use-loose-git-rules && branch-exists-on-remote


### PR DESCRIPTION
I like having the git history on the PR better reflect the changes that have been made since the PR was initially pushed, even if that includes merge commits.

Repos can still opt out of strict git rules by setting `use-loose-git-rules` in `runger-config`.