### PR TITLE
[gol] Add relative date

### DIFF
--- a/bin/gol
+++ b/bin/gol
@@ -6,4 +6,4 @@
 
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
-git log --oneline "$@"
+git log --pretty=format:"%C(yellow)%h%C(reset) %s %C(green)(%ar)%C(reset)" "$@"


### PR DESCRIPTION
When I search over or scroll back through the `gol` output, I am usually wondering how long ago each commit was made. Now, I'll know.