### PR TITLE
[extract] Handle patterns with forward slashes

### DIFF
--- a/bin/extract
+++ b/bin/extract
@@ -14,14 +14,13 @@
 
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
-pattern="$1"
-
-perl -nle '
-  if (/'"$pattern"'/) {
+perl -s -nle '
+  $regex = qr/$pattern/;
+  if (/$regex/) {
     if (defined $1) {
       print $1;
     } else {
       print $&;
     }
   }
-'
+' -- -pattern="$1"


### PR DESCRIPTION
https://x.com/i/grok?conversation=1903875146567320028

`extract` was erroring if the pattern had a `/`. This change fixes it.

Error we were getting:

```
$ cat personal/random.txt | extract 'vue/'
syntax error at -e line 2, near "/) "
Execution of -e aborted due to compilation errors.
```