### PR TITLE
[vs-code-scrollback-viewer] Create temp file in a /tmp/ subdirectory

### DIFF
--- a/bin/vs-code-scrollback-viewer
+++ b/bin/vs-code-scrollback-viewer
@@ -6,7 +6,9 @@
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
 # The .txt extension ensures VS Code doesn't try to guess a language and just uses plain text.
-tempfile=$(mktemp /tmp/code-stdin-XXXXXX.txt)
+directory=/tmp/scrollback-viewer
+mkdir -p "$directory"
+tempfile=$(mktemp "$directory/XXXXXX.txt")
 cat > "$tempfile"
 # Add linuxbrew to PATH, so we have `sd`.
 export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"


### PR DESCRIPTION
The advantage of this is that I can open that subdirectory with `s /tmp/scrollback-viewer` and tell VS Code to trust files in that directory. Then, when VS Code opens files from that directory, it will open them in my probably-already-open VS Code instance that has another trusted directory open, rather than opening a new VS Code window to sandbox an untrusted file.