### PR TITLE
[check-gem] Add command to fetch, unpack, and open a gem

### DIFF
--- a/bin/check-gem
+++ b/bin/check-gem
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# [check] a [gem] (for security risks or other reasons) before actually installing it.
+#
+# Example(s):
+#   check-gem shaped
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+gem_name=$1
+
+cd ~/Downloads
+gem fetch "$gem_name"
+gem unpack "$gem_name"-*.gem
+$EDITOR "$(find . -type d -name "$gem_name-*" | head -1)"


### PR DESCRIPTION
https://www.perplexity.ai/search/f52ee515-8047-4d7d-93f6-c3cf09146562

Sometimes I want to check out a gem, for security reasons, before actually installing it. Also, I don't want to necessarily trust that the GitHub source accurately reflects what will be in the distributed gem, so we download the gem from the RubyGems source, rather than from GitHub.