### PR TITLE
Remove suggestion to go back to upstream pry-byebug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem 'guard-shell'
 gem 'living_document'
 gem 'memo_wise'
 gem 'octokit'
-# Go back to upstream if/when https://github.com/deivid-rodriguez/pry-byebug/pull/ 428 is merged.
 gem 'pry-byebug', require: false, github: 'davidrunger/pry-byebug'
 gem 'rainbow'
 gem 'redis'


### PR DESCRIPTION
The mentioned PR ( https://github.com/deivid-rodriguez/pry-byebug/pull/ 428 ) is not really the only advantage of using the `david_runger/pry-byebug` fork. Another advantage is that the fork uses `runger_byebug` rather than `byebug` (where `runger_byebug` has advantages, like this PR: https://github.com/davidrunger/runger_byebug/pull/10 ). Therefore, remove the suggestion to go back to the upstream `pry-byebug` after https://github.com/deivid-rodriguez/pry-byebug/pull/ 428 has been merged (which it just was, although it hasn't yet been released via RubyGems).