### PR TITLE
[update-gems] Commit directly to branch (not to main)

### DIFF
--- a/tools/update-gems.sh
+++ b/tools/update-gems.sh
@@ -24,13 +24,11 @@ for dir in $(my-repos) ; do
       bundle update
 
       if ! git diff --quiet ; then
+        gfcob "$branch_name"
         git add .
         git commit --message "Update gems
 
 \`bundle update\`"
-        gfcob "$branch_name"
-        gcp main
-        git branch --force main origin/main
         hpr
       fi
     fi


### PR DESCRIPTION
Since https://github.com/davidrunger/dotfiles/pull/447 , it is no longer necessary to commit to `main`, since we will now autostash the changes when rebasing `main` when running `gfcob`.