### PR TITLE
[update-npm-packages] Commit directly to branch (not to main)

### DIFF
--- a/tools/update-npm-packages.sh
+++ b/tools/update-npm-packages.sh
@@ -21,13 +21,11 @@ update_and_create_pr() {
 
   # If there are changes, commit them and open a PR.
   if ! git diff --quiet; then
+    gfcob "$branch_name"
     git add .
     git commit --message "Update NPM packages
 
 \`$update_command\`"
-    gfcob "$branch_name"
-    gcp main
-    git branch --force main origin/main
     hpr
   fi
 }


### PR DESCRIPTION
Since https://github.com/davidrunger/dotfiles/pull/447 , it is no longer necessary to commit to `main`, since we will now autostash the changes when rebasing `main` when running `gfcob`.