### PR TITLE
[update-tocs] Commit directly to branch (not to main)

### DIFF
--- a/tools/update-tocs.sh
+++ b/tools/update-tocs.sh
@@ -28,13 +28,11 @@ for dir in $(my-repos) ; do
         # The TOC is up to date. The only diff is updating the updated-at timestamp.
         gco .
       else
+        gfcob "$branch_name"
         git add .
         git commit --message "Update table of contents
 
 \`$update_command\`"
-        gfcob "$branch_name"
-        gcp main
-        git branch --force main origin/main
         hpr
       fi
     fi


### PR DESCRIPTION
Since https://github.com/davidrunger/dotfiles/pull/447 , it is no longer necessary to commit to `main`, since we will now autostash the changes when rebasing `main` when running `gfcob`.