### PR TITLE
[update-npm-packages] Update transitive dependencies w/ 'pnpm update'

### DIFF
--- a/tools/update-npm-packages.sh
+++ b/tools/update-npm-packages.sh
@@ -40,7 +40,7 @@ for dir in $(my-repos) ; do
 
     if git diff --quiet && ! branch-exists "$branch_name" ; then
       if [ -f pnpm-lock.yaml ]; then
-        update_and_create_pr "pnpx npm-check-updates --upgrade && pnpm install && pnpm dedupe"
+        update_and_create_pr "pnpx npm-check-updates --upgrade && pnpm install && pnpm update && pnpm dedupe"
       elif [ -f yarn.lock ]; then
         update_and_create_pr "yarn upgrade --latest && pnpx yarn-deduplicate yarn.lock"
       fi


### PR DESCRIPTION
I think that `pnpx npm-check-updates --upgrade && pnpm install` doesn't update transitive dependencies for which there is no update available for the package that we reference in our `package.json`. In contrast, I think that `pnpm update` will update these dependencies. So, let's run `pnpm update`, in addition to `pnpx npm-check-updates --upgrade && pnpm install`, to also update transitive dependencies for which there is no available update for the package that we have in `package.json`.