### PR TITLE
[run-rubocop] Look for rubocop in a gemspec, too (not just Gemfile)

### DIFF
--- a/bin/run-rubocop
+++ b/bin/run-rubocop
@@ -5,6 +5,7 @@
 readarray -t all_git_files < <(git ls-files)
 
 # If rubocop is listed in the Gemfile or gemspec ...
+# We expect there to be either 0 or 1 gemspec files, in which case SC2144 is not relevant.
 # shellcheck disable=SC2144
 if {
   { [ -f Gemfile ] && rg --quiet "rubocop" Gemfile ; } || \

--- a/bin/run-rubocop
+++ b/bin/run-rubocop
@@ -4,8 +4,12 @@
 
 readarray -t all_git_files < <(git ls-files)
 
-# If rubocop is listed in the  Gemfile...
-if [ -f Gemfile ] && rg --quiet "rubocop" Gemfile; then
+# If rubocop is listed in the Gemfile or gemspec ...
+# shellcheck disable=SC2144
+if {
+  { [ -f Gemfile ] && rg --quiet "rubocop" Gemfile ; } || \
+    { [ -f *.gemspec ] && rg --quiet "rubocop" ./*.gemspec ; } ;
+} ; then
   # and there is a `bin/rubocop` executable, then run it.
   if [ -f bin/rubocop ]; then
     bin/rubocop "${all_git_files[@]}" --force-exclusion "$@"


### PR DESCRIPTION
Some gems (e.g. `paper_trail`) put all of their dependencies (including development dependencies like rubocop) in the gemspec, rather than in a Gemfile. This change will detect, even in such cases, that we can and should run rubocop using `bundle exec rubocop` or `bin/rubocop`.