### PR TITLE
[gup] Add '--allow-empty' flag to 'git commit' command

### DIFF
--- a/bin/gup
+++ b/bin/gup
@@ -20,4 +20,4 @@ if use-strict-git-rules && ! may-edit-latest-commit ; then
   exit 1
 fi
 
-git add -A . && git commit --amend --no-edit
+git add -A . && git commit --amend --no-edit --allow-empty


### PR DESCRIPTION
Sometimes, I want to clear all changes (maybe with `gcoom <file>`), yet retain the commit message. This change makes that easier.