### PR TITLE
[runger-config] Remove 'commit-to-main: true'

### DIFF
--- a/.runger-config.yml
+++ b/.runger-config.yml
@@ -1,2 +1,1 @@
-commit-to-main: true
 expected-num-github-checks: 5


### PR DESCRIPTION
This will restore the default of not allowing direct commits to main (instead requiring a branch and PR).

Benefit: no accidental commits to main.

I used to make some commits directly to main, but nowadays I pretty much always like to do a PR, to run tests and to have an easy place to link to the changes and/or review them in the future.