### PR TITLE
[gac] Move from an alias to an executable script

### DIFF
--- a/bin-lint/prettier
+++ b/bin-lint/prettier
@@ -9,7 +9,7 @@ set -euo pipefail # exit on any error, don't allow undefined variables, pipes do
 readarray -t files_for_prettier < <(
   changed-not-deleted-files | \
     rg '\.' | \
-    rg -v '\.(conf|cr|haml|lock|node-version|prettierignore|rb|sh|toml|zshrc)$' || \
+    rg -v '\.(conf|cr|haml|lock|node-version|prettierignore|rb|sh|toml|zsh(rc)?)$' || \
     true
 )
 

--- a/bin/gac
+++ b/bin/gac
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# [g]it [a]dd . && git [c]ommit
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+ga . && gcom

--- a/shell/aliases.zsh
+++ b/shell/aliases.zsh
@@ -11,7 +11,6 @@ alias down='cd ~/Downloads'
 alias fix='git diff --name-only | uniq | xargs $EDITOR'
 alias fs='format-sql'
 alias fsk='redis-cli -n 1 FLUSHDB && sk' # `-n 1` because of `REDIS_DATABASE_NUMBER=1` in `.env`
-alias gac='ga . && gcom'
 alias gba='GIT_PAGER=cat git branch -vv'
 alias gbdf='git branch -D $(active-branches | fzf)'
 alias gcme='git commit --allow-empty --message'


### PR DESCRIPTION
One advantage of moving `gac` from an alias to an executable script is that it better responds to env var customizations.

For example, when it was an alias, `GIT_EDITOR=nvim gac` would open my default editor to edit the commit message. I think that this is because it expanded to `GIT_EDITOR=nvim ga . && gcom` and so the `GIT_EDITOR` env var only applied to the `ga .` part and not to the `gcom` part.

In contrast, when it's a script, `GIT_EDITOR=nvim gac` does use `nvim` to edit the commit message, since the `GIT_EDITOR` env var is applied to not only the `ga .` part of the command, but also the `gcom` part.