### PR TITLE
[mrg] Ignore ripgrep config path

### DIFF
--- a/bin/mrg
+++ b/bin/mrg
@@ -30,7 +30,7 @@ class MultiLevelRipgrep < CommandLineProgram
     *@initial_filters, @final_search = arguments
 
     line_matches =
-      `#{command}`.split("\n").map do |line|
+      `RIPGREP_CONFIG_PATH= #{command}`.split("\n").map do |line|
         line.
           match(/(?<prefix>\A\e\[0m\e\[35m\S+:\e\[0m\e\[32m\d+\e\[0m:)(?<remainder>.*\z)/).
           named_captures.symbolize_keys


### PR DESCRIPTION
This is a followup to #609, which added `--hyperlink-format=kitty` as a default ripgrep config. However, this causes the regex in `mrg` not to detect any matches. So, this change ignores that config by setting `RIPGREP_CONFIG_PATH` to a blank variable when invoking `rg`.