### PR TITLE
[rrp] Ignore 'nodecommit' processes

### DIFF
--- a/bin/rrp
+++ b/bin/rrp
@@ -5,7 +5,7 @@
 processes_to_ignore="e?grep|Slack|Postman|GitHub|rubocop|open-pr-in-browser|Helper|\bbrew\b\
 |solargraph|ionodecache|ruby-lsp|fuzzy-ruby-server|node-ipc|node.mojom|code.*extensions\
 |esbuild.*linux.*ping|wait-for-gh-checks|merge-prs|fusermount3|inode_switch_wbs|ruby/gems\
-|nodetach"
+|nodetach|nodecommit"
 processes_to_quit='ruby'
 processes_to_term='spring'
 processes_to_int='puma|sidekiq|rspec'


### PR DESCRIPTION
Before, there was a process like this that we were trying to kill, but which we probably shouldn't try to kill, and which wasn't being killed, anyway:

```
87623 /usr/share/code/code --type=renderer [...],no_channel --user-data-dir=/home/david/.config/Code --standard-schemes=vscode-webview,vscode-file --enable-sandbox --secure-schemes=vscode-webview,vscode-file --cors-schemes=vscode-webview,vscode-file --fetch-schemes=vscode-webview,vscode-file --service-worker-schemes=vscode-webview --code-cache-schemes=vscode-webview,vscode-file --app-path=/usr/share/code/resources/app --enable-sandbox --enable-blink-features=HighlightAPI --js-flags=--nodecommit_pooled_pages --disable-blink-features=FontMatchingCTMigration,StandardizedBrowserZoom, --lang=en-US --num-raster-threads=2 --enable-main-frame-before-activation --renderer-client-id=4 [...] --shared-files=v8_context_snapshot_data:100 [...] --enable-features=DocumentPolicyIncludeJSCallStacksInCrashReports --disable-features=CalculateNativeWinOcclusion,SpareRendererForSitePerProcess --variations-seed-version [...]
```

This change will ignore such a process.