### PR TITLE
[rrp] Use 'rg' (rather than grep)

### DIFF
--- a/bin/rrp
+++ b/bin/rrp
@@ -2,7 +2,7 @@
 
 # Stop/kill [rr]uby [p]rocesses.
 
-processes_to_ignore="e?grep|Slack|Postman|GitHub|rubocop|open-pr-in-browser|Helper|\bbrew\b\
+processes_to_ignore=" rg |Slack|Postman|GitHub|rubocop|open-pr-in-browser|Helper|\bbrew\b\
 |solargraph|ionodecache|ruby-lsp|fuzzy-ruby-server|node-ipc|node.mojom|code.*extensions\
 |esbuild.*linux.*ping|wait-for-gh-checks|merge-prs|fusermount3|inode_switch_wbs|ruby/gems\
 |nodetach|nodecommit"
@@ -29,17 +29,17 @@ stop_processes() {
 
   # print the processes to end
   echo 'Trying to kill ...'
-  pid-cmd | grep -E "$processes_to_kill" | grep -Ev "$processes_to_ignore"
+  pid-cmd | rg -v "$processes_to_ignore" | rg "$processes_to_kill"
 
   # end the processes
-  pid-cmd | grep -E "$processes_to_quit" | grep -Ev "$processes_to_ignore" | awk '{print $1}' | xargs -r kill -QUIT
-  pid-cmd | grep -E "$processes_to_int" | grep -Ev "$processes_to_ignore" | awk '{print $1}' | xargs -r kill -INT
-  pid-cmd | grep -E "$processes_to_term" | grep -Ev "$processes_to_ignore" | awk '{print $1}' | xargs -r kill -TERM
+  pid-cmd | rg "$processes_to_quit" | rg -v "$processes_to_ignore" | awk '{print $1}' | xargs -r kill -QUIT
+  pid-cmd | rg "$processes_to_int" | rg -v "$processes_to_ignore" | awk '{print $1}' | xargs -r kill -INT
+  pid-cmd | rg "$processes_to_term" | rg -v "$processes_to_ignore" | awk '{print $1}' | xargs -r kill -TERM
   sleep 0.5 # wait a moment for processes to exit
 
   # print processes that are still running (though there might be none)
   printf "\nRemaining processes:\n"
-  pid-cmd | grep -E "$processes_to_kill" | grep -Ev "$processes_to_ignore"
+  pid-cmd | rg -v "$processes_to_ignore" | rg "$processes_to_kill"
 
   return 0
 }


### PR DESCRIPTION
`rg` automatically uses color to highlight matches, which can be helpful to understand why a process is being matched (especially if the process's command is really long). Also, `rg` is generally faster (not that it probably matters much, when grepping such relatively short strings as the output of `pid-cmd`).