### PR TITLE
[gce] Forward any/all arguments on to 'git commit' command

### DIFF
--- a/bin/gce
+++ b/bin/gce
@@ -5,4 +5,4 @@
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
 verify-on-ok-branch
-git commit --allow-empty
+git commit --allow-empty "$@"


### PR DESCRIPTION
This allows committing from the command line (e.g. `gce -m 'Z Specs'`).