### PR TITLE
[install] Add commented-out bundler-why plugin installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -46,6 +46,7 @@ touch ~/.pry_history
 # brew bundle
 
 # bundle install
+# bundle plugin install bundler-why
 
 # pnpm add --global http-server live-server prettier typescript tsx
 


### PR DESCRIPTION
It's a great plugin. https://github.com/jaredbeck/bundler-why

I'm adding it commented out, though, because I want the install script to be as fast as reasonably possible, and this will only be necessary to run once after upgrading to a new Ruby version, I think, so it's usually not necessary and therefore not worth the time.