### PR TITLE
[kitty] Use custom keyboard shortcuts rather than scrollback_pager

### DIFF
--- a/bin/vs-code-scrollback-viewer
+++ b/bin/vs-code-scrollback-viewer
@@ -10,7 +10,4 @@ directory=/tmp/scrollback-viewer
 mkdir -p "$directory"
 tempfile=$(mktemp "$directory/XXXXXX.txt")
 cat > "$tempfile"
-# Add linuxbrew to PATH, so we have `sd`.
-export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
-sd '\x1B\[[0-9;]*[a-zA-Z]' '' "$tempfile"
 code "$tempfile"

--- a/kitty/kitty.conf
+++ b/kitty/kitty.conf
@@ -8,7 +8,6 @@ cursor_blink_interval 0
 shell_integration enable no-cursor
 
 scrollback_lines -1
-scrollback_pager vs-code-scrollback-viewer
 
 tab_bar_edge top
 tab_bar_style slant
@@ -36,3 +35,5 @@ include kitty_${KITTY_OS}.conf
 
 # Copy all text to clipboard. https://www.perplexity.ai/search/54e3a18d-eafe-4099-8ab5-e8d013cd4408
 map ctrl+shift+a pipe @text clipboard cat
+map ctrl+shift+g launch --stdin-source=@last_cmd_output --type=background vs-code-scrollback-viewer
+map ctrl+shift+h launch --stdin-source=@screen_scrollback --type=background vs-code-scrollback-viewer


### PR DESCRIPTION
This approach better handles lines that are longer than the terminal width. (With the previous approach, they'd be hard broken, which was pretty annoying.) Also, this approach seems significantly faster.