### PR TITLE
[mise] Respect '.node-version' files

### DIFF
--- a/mise.global-config-symlink.toml
+++ b/mise.global-config-symlink.toml
@@ -1,6 +1,7 @@
 [settings]
 activate_aggressive = true
 disable_tools = ["ruby"]
+idiomatic_version_file_enable_tools = ["node"]
 
 [settings.status]
 missing_tools = "always"


### PR DESCRIPTION
https://github.com/jdx/mise/discussions/4345

This warning appeared in my `david_runger` repo after updating mise:

```
mise WARN  deprecated [idiomatic_version_file_enable_tools]:                                                                                                                             
Idiomatic version files like ~/code/david_runger/.node-version are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.

You can remove this warning by explicitly enabling idiomatic version files for node with:

    mise settings add idiomatic_version_file_enable_tools node

You can disable idiomatic version files with:

    mise settings add idiomatic_version_file_enable_tools "[]"

See https://github.com/jdx/mise/discussions/4345 for more information.
```

This change makes the warning go away and I think will preserve the behavior that I want.