### PR TITLE
[irbrc] Disable IRB splash banner

### DIFF
--- a/irbrc.rb
+++ b/irbrc.rb
@@ -21,3 +21,5 @@ IRB::Irb.class_eval do
     puts("#=> #{@context.last_value.ai}")
   end
 end
+
+IRB.conf[:SHOW_BANNER] = false


### PR DESCRIPTION
I don't hate the banner, and it's sort of fun, but it's a bit distracting and uses up more vertical space in my terminal than I think is worthwhile.