### PR TITLE
[brup] Add 'pnpm self-update'

### DIFF
--- a/bin/brup
+++ b/bin/brup
@@ -30,4 +30,9 @@ update_oh_my_zsh() {
   "$ZSH/tools/changelog.sh" "$sha_after" "$sha_before"
 }
 
-(update_homebrew && echo && update_oh_my_zsh) |& tee "$output_log_file"
+(update_homebrew &&
+  echo &&
+  update_oh_my_zsh &&
+  echo &&
+  pnpm self-update
+) |& tee "$output_log_file"


### PR DESCRIPTION
I think that including `pnpm self-update` in `brup` will be better than running it manually every once in a while (usually after a run some `pnpm` command and it prints info about a newer version being available).