### PR TITLE
[brup] Run 'pnpm self-update' first

### DIFF
--- a/bin/brup
+++ b/bin/brup
@@ -30,9 +30,9 @@ update_oh_my_zsh() {
   "$ZSH/tools/changelog.sh" "$sha_after" "$sha_before"
 }
 
-(update_homebrew &&
+(pnpm self-update &&
   echo &&
-  update_oh_my_zsh &&
+  update_homebrew &&
   echo &&
-  pnpm self-update
+  update_oh_my_zsh
 ) |& tee "$output_log_file"


### PR DESCRIPTION
I might want to start using `pnpm` soon after running `brup`. By putting the `pnpm` update first, that will hopefully complete relatively quickly, so that the `pnpm` version doesn't change while using it. This is better than having to first wait for `update_homebrew` and `update_oh_my_zsh` to complete before being able confidently to use `pnpm`.