### PR TITLE
Remove pnpm minimumReleaseAgeExclude list

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,1 @@
 minimumReleaseAge: 7200 # Wait 5 days before installing new releases.
-minimumReleaseAgeExclude:
-  - '@types/node@25.9.2'
-  - prettier@3.8.4


### PR DESCRIPTION
We added this so that our lockfile would be okay after adding `minimumReleaseAge: 7200`. Now that it has been more than 7200 minutes since we added that constraint, we don't need this list of excludes anymore.